### PR TITLE
feat(cli): wire Should-Have FR gaps — relative symlinks, _meta.yaml display, --version flag

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -12,7 +12,11 @@ import (
 )
 
 func newDeployCmd(app *App) *cobra.Command {
-	var assetType string
+	var (
+		assetType string
+		relative  bool
+		absolute  bool
+	)
 
 	cmd := &cobra.Command{
 		Use:   "deploy <asset> [assets...]",
@@ -78,6 +82,20 @@ Asset references can be:
 				return nil
 			}
 
+			// Resolve symlink strategy: flag > config > default (absolute)
+			strategy := nd.SymlinkAbsolute
+			if sm, smErr := app.SourceManager(); smErr == nil {
+				cfg := sm.Config()
+				if cfg.SymlinkStrategy != "" {
+					strategy = cfg.SymlinkStrategy
+				}
+			}
+			if relative {
+				strategy = nd.SymlinkRelative
+			} else if absolute {
+				strategy = nd.SymlinkAbsolute
+			}
+
 			// Build deploy requests
 			reqs := make([]deploy.DeployRequest, len(assets))
 			for i, a := range assets {
@@ -86,6 +104,7 @@ Asset references can be:
 					Scope:       app.Scope,
 					ProjectRoot: app.ProjectRoot,
 					Origin:      nd.OriginManual,
+					Strategy:    strategy,
 				}
 			}
 
@@ -162,6 +181,9 @@ Asset references can be:
 		}
 		return types, cobra.ShellCompDirectiveNoFileComp
 	})
+	cmd.Flags().BoolVar(&relative, "relative", false, "use relative symlinks (overrides config)")
+	cmd.Flags().BoolVar(&absolute, "absolute", false, "use absolute symlinks (overrides config)")
+	cmd.MarkFlagsMutuallyExclusive("relative", "absolute")
 	return cmd
 }
 

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -162,6 +162,68 @@ func TestDeployCmd_Multiple(t *testing.T) {
 	}
 }
 
+func TestDeployCmd_RelativeFlag(t *testing.T) {
+	configPath, _ := setupDeployEnv(t)
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--config", configPath, "deploy", "--relative", "greeting"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Resolve the agent global_dir from the config to find the deployed symlink
+	// configPath = <tmp>/.config/nd/config.yaml → three Dir() calls to reach tmp
+	tmp := filepath.Dir(filepath.Dir(filepath.Dir(configPath)))
+	agentDir := filepath.Join(tmp, ".claude")
+	linkPath := filepath.Join(agentDir, "skills", "greeting")
+
+	target, readErr := os.Readlink(linkPath)
+	if readErr != nil {
+		t.Fatalf("expected symlink at %s: %v", linkPath, readErr)
+	}
+	// A relative symlink target must not be absolute
+	if filepath.IsAbs(target) {
+		t.Errorf("expected relative symlink, got absolute target: %q", target)
+	}
+}
+
+func TestDeployCmd_AbsoluteFlag(t *testing.T) {
+	configPath, _ := setupDeployEnv(t)
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--config", configPath, "deploy", "--absolute", "greeting"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tmp := filepath.Dir(filepath.Dir(filepath.Dir(configPath)))
+	agentDir := filepath.Join(tmp, ".claude")
+	linkPath := filepath.Join(agentDir, "skills", "greeting")
+
+	target, readErr := os.Readlink(linkPath)
+	if readErr != nil {
+		t.Fatalf("expected symlink at %s: %v", linkPath, readErr)
+	}
+	// An absolute symlink target must be an absolute path
+	if !filepath.IsAbs(target) {
+		t.Errorf("expected absolute symlink, got relative target: %q", target)
+	}
+}
+
 func TestDeployCmd_Completions(t *testing.T) {
 	configPath, _ := setupDeployEnv(t)
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -54,11 +54,13 @@ func newListCmd(app *App) *cobra.Command {
 
 			// Apply filters
 			type listEntry struct {
-				Type   string `json:"type"`
-				Name   string `json:"name"`
-				Source string `json:"source"`
-				Status string `json:"status"`
-				IsDir  bool   `json:"is_dir"`
+				Type        string   `json:"type"`
+				Name        string   `json:"name"`
+				Source      string   `json:"source"`
+				Status      string   `json:"status"`
+				IsDir       bool     `json:"is_dir"`
+				Description string   `json:"description,omitempty"`
+				Tags        []string `json:"tags,omitempty"`
 			}
 
 			var entries []listEntry
@@ -81,13 +83,18 @@ func newListCmd(app *App) *cobra.Command {
 					}
 				}
 
-				entries = append(entries, listEntry{
+				entry := listEntry{
 					Type:   string(a.Type),
 					Name:   a.Name,
 					Source: a.SourceID,
 					Status: status,
 					IsDir:  a.IsDir,
-				})
+				}
+				if a.Meta != nil {
+					entry.Description = a.Meta.Description
+					entry.Tags = a.Meta.Tags
+				}
+				entries = append(entries, entry)
 			}
 
 			if app.JSON {
@@ -104,7 +111,11 @@ func newListCmd(app *App) *cobra.Command {
 				if e.Status == "deployed" {
 					marker = "*"
 				}
-				printHuman(w, "%s %-15s  %-30s  %-15s\n", marker, e.Type, e.Name, e.Source)
+				if e.Description != "" {
+					printHuman(w, "%s %-15s  %-30s  %-15s  %s\n", marker, e.Type, e.Name, e.Source, e.Description)
+				} else {
+					printHuman(w, "%s %-15s  %-30s  %-15s\n", marker, e.Type, e.Name, e.Source)
+				}
 			}
 
 			return nil

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -150,3 +150,91 @@ func TestListCmd_JSON(t *testing.T) {
 		t.Errorf("expected status ok, got %q", resp.Status)
 	}
 }
+
+func TestListCmd_ContextMeta(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, ".config", "nd")
+	os.MkdirAll(configDir, 0o755)
+	os.MkdirAll(filepath.Join(configDir, "state"), 0o755)
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	srcDir := filepath.Join(tmp, "my-source")
+	contextDir := filepath.Join(srcDir, "context", "my-rules")
+	os.MkdirAll(contextDir, 0o755)
+	os.WriteFile(filepath.Join(contextDir, "CLAUDE.md"), []byte("# Rules"), 0o644)
+	os.WriteFile(filepath.Join(contextDir, "_meta.yaml"), []byte("description: Project-specific coding rules\ntags:\n  - coding\n  - rules\n"), 0o644)
+
+	agentDir := filepath.Join(tmp, ".claude")
+	os.MkdirAll(agentDir, 0o755)
+
+	cfg := "version: 1\ndefault_scope: global\ndefault_agent: claude-code\nsymlink_strategy: absolute\nsources:\n  - id: my-source\n    type: local\n    path: " + srcDir + "\nagents:\n  - name: claude-code\n    global_dir: " + agentDir + "\n"
+	os.WriteFile(configPath, []byte(cfg), 0o644)
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--config", configPath, "list"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Project-specific coding rules") {
+		t.Errorf("expected meta description in output, got: %s", got)
+	}
+}
+
+func TestListCmd_ContextMetaJSON(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, ".config", "nd")
+	os.MkdirAll(configDir, 0o755)
+	os.MkdirAll(filepath.Join(configDir, "state"), 0o755)
+	configPath := filepath.Join(configDir, "config.yaml")
+
+	srcDir := filepath.Join(tmp, "my-source")
+	contextDir := filepath.Join(srcDir, "context", "my-rules")
+	os.MkdirAll(contextDir, 0o755)
+	os.WriteFile(filepath.Join(contextDir, "CLAUDE.md"), []byte("# Rules"), 0o644)
+	os.WriteFile(filepath.Join(contextDir, "_meta.yaml"), []byte("description: Project-specific coding rules\ntags:\n  - coding\n  - rules\n"), 0o644)
+
+	agentDir := filepath.Join(tmp, ".claude")
+	os.MkdirAll(agentDir, 0o755)
+
+	cfg := "version: 1\ndefault_scope: global\ndefault_agent: claude-code\nsymlink_strategy: absolute\nsources:\n  - id: my-source\n    type: local\n    path: " + srcDir + "\nagents:\n  - name: claude-code\n    global_dir: " + agentDir + "\n"
+	os.WriteFile(configPath, []byte(cfg), 0o644)
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--config", configPath, "--json", "list"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp output.JSONResponse
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out.String())
+	}
+	if resp.Status != "ok" {
+		t.Errorf("expected status ok, got %q", resp.Status)
+	}
+
+	// Marshal Data back to JSON and check for the description field
+	dataBytes, err := json.Marshal(resp.Data)
+	if err != nil {
+		t.Fatalf("failed to re-marshal data: %v", err)
+	}
+	if !strings.Contains(string(dataBytes), "Project-specific coding rules") {
+		t.Errorf("expected meta description in JSON data, got: %s", string(dataBytes))
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,12 +13,14 @@ import (
 	"github.com/armstrongl/nd/internal/nd"
 	"github.com/armstrongl/nd/internal/tui"
 	tuiapp "github.com/armstrongl/nd/internal/tui/app"
+	"github.com/armstrongl/nd/internal/version"
 )
 
 // NewRootCmd creates the root command with all global flags and subcommands.
 func NewRootCmd(app *App) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           "nd",
+		Version:       version.String(),
 		Short:         "Napoleon Dynamite — coding agent asset manager",
 		Long:          "nd manages coding agent assets (skills, commands, rules, etc.) via symlink deployment.",
 		SilenceUsage:  true,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -77,6 +77,24 @@ func TestScopeFlagCompletion(t *testing.T) {
 	}
 }
 
+func TestRootCmd_VersionFlag(t *testing.T) {
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+	rootCmd.SetArgs([]string{"--version"})
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "nd version") {
+		t.Errorf("expected version info in output, got: %s", got)
+	}
+}
+
 func TestWithExitCode(t *testing.T) {
 	err := withExitCode(2, &exitError{code: 1, err: nil})
 	code, ok := exitCodeFromError(err)

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -102,6 +102,7 @@ type DeployRequest struct {
 	Scope       nd.Scope
 	ProjectRoot string
 	Origin      nd.DeployOrigin
+	Strategy    nd.SymlinkStrategy
 }
 
 // DeployResult describes the outcome of a single deployment.
@@ -170,7 +171,6 @@ func (e *Engine) Deploy(req DeployRequest) (*DeployResult, error) {
 
 		return e.store.Save(st)
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,15 @@ func (e *Engine) deployOne(req DeployRequest, st *state.DeploymentState) (*Deplo
 		return nil, fmt.Errorf("permission denied: cannot write to %s: %w", parentDir, err)
 	}
 
-	if err := e.symlink(req.Asset.SourcePath, linkPath); err != nil {
+	target := req.Asset.SourcePath
+	if req.Strategy == nd.SymlinkRelative {
+		rel, err := filepath.Rel(filepath.Dir(linkPath), req.Asset.SourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("compute relative path from %s to %s: %w", linkPath, req.Asset.SourcePath, err)
+		}
+		target = rel
+	}
+	if err := e.symlink(target, linkPath); err != nil {
 		return nil, fmt.Errorf("create symlink at %s: %w", linkPath, err)
 	}
 
@@ -235,6 +243,7 @@ func (e *Engine) deployOne(req DeployRequest, st *state.DeploymentState) (*Deplo
 		Scope:       req.Scope,
 		ProjectPath: req.ProjectRoot,
 		Origin:      req.Origin,
+		Strategy:    req.Strategy,
 		DeployedAt:  e.now(),
 	}
 	st.Deployments = append(st.Deployments, dep)
@@ -399,7 +408,6 @@ func (e *Engine) DeployBulk(reqs []DeployRequest) (*BulkDeployResult, error) {
 
 		return e.store.Save(st)
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +455,6 @@ func (e *Engine) RemoveBulk(reqs []RemoveRequest) (*BulkRemoveResult, error) {
 
 		return e.store.Save(st)
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -77,12 +78,12 @@ type fakeFileInfo struct {
 	mode os.FileMode
 }
 
-func (f fakeFileInfo) Name() string        { return "fake" }
-func (f fakeFileInfo) Size() int64         { return 0 }
-func (f fakeFileInfo) Mode() os.FileMode   { return f.mode }
-func (f fakeFileInfo) ModTime() time.Time  { return time.Time{} }
-func (f fakeFileInfo) IsDir() bool         { return f.mode.IsDir() }
-func (f fakeFileInfo) Sys() any            { return nil }
+func (f fakeFileInfo) Name() string       { return "fake" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return f.mode.IsDir() }
+func (f fakeFileInfo) Sys() any           { return nil }
 
 func TestNewEngine(t *testing.T) {
 	store := newMockStore()
@@ -281,9 +282,11 @@ func TestDeployBulkPartialFailure(t *testing.T) {
 func TestRemoveAsset(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "review",
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "review",
 			SourcePath: "/s/skills/review", LinkPath: "/home/user/.claude/skills/review",
-			Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+			Scope: nd.ScopeGlobal, Origin: nd.OriginManual,
+		},
 	}
 
 	removed := false
@@ -308,8 +311,10 @@ func TestRemoveAsset(t *testing.T) {
 func TestRemoveAlreadyGone(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "review",
-			LinkPath: "/home/user/.claude/skills/review", Scope: nd.ScopeGlobal},
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "review",
+			LinkPath: "/home/user/.claude/skills/review", Scope: nd.ScopeGlobal,
+		},
 	}
 
 	engine := deploy.New(store, testAgent(), t.TempDir())
@@ -327,10 +332,14 @@ func TestRemoveAlreadyGone(t *testing.T) {
 func TestRemoveBulk(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "a",
-			LinkPath: "/home/user/.claude/skills/a", Scope: nd.ScopeGlobal},
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "b",
-			LinkPath: "/home/user/.claude/skills/b", Scope: nd.ScopeGlobal},
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "a",
+			LinkPath: "/home/user/.claude/skills/a", Scope: nd.ScopeGlobal,
+		},
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "b",
+			LinkPath: "/home/user/.claude/skills/b", Scope: nd.ScopeGlobal,
+		},
 	}
 
 	engine := deploy.New(store, testAgent(), t.TempDir())
@@ -481,10 +490,12 @@ func TestDeployForeignSymlinkNonContext(t *testing.T) {
 func TestDeployManagedSymlinkSameAsset(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "src", AssetType: nd.AssetSkill, AssetName: "review",
+		{
+			SourceID: "src", AssetType: nd.AssetSkill, AssetName: "review",
 			SourcePath: "/sources/skills/review",
 			LinkPath:   "/home/user/.claude/skills/review",
-			Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+			Scope:      nd.ScopeGlobal, Origin: nd.OriginManual,
+		},
 	}
 
 	engine := deploy.New(store, testAgent(), t.TempDir())
@@ -518,10 +529,12 @@ func TestDeployManagedSymlinkSameAsset(t *testing.T) {
 func TestDeployManagedSymlinkDifferentAsset(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "old", AssetType: nd.AssetSkill, AssetName: "old-review",
+		{
+			SourceID: "old", AssetType: nd.AssetSkill, AssetName: "old-review",
 			SourcePath: "/old/skills/old-review",
 			LinkPath:   "/home/user/.claude/skills/review",
-			Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+			Scope:      nd.ScopeGlobal, Origin: nd.OriginManual,
+		},
 	}
 
 	removedPath := ""
@@ -664,8 +677,10 @@ func TestRemoveLoadError(t *testing.T) {
 func TestRemoveBulkPartialFailure(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "a",
-			LinkPath: "/home/user/.claude/skills/a", Scope: nd.ScopeGlobal},
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "a",
+			LinkPath: "/home/user/.claude/skills/a", Scope: nd.ScopeGlobal,
+		},
 	}
 
 	engine := deploy.New(store, testAgent(), t.TempDir())
@@ -711,9 +726,11 @@ func TestDeployLoadError(t *testing.T) {
 func TestRemoveSymlinkError(t *testing.T) {
 	store := newMockStore()
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "review",
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "review",
 			SourcePath: "/s/skills/review", LinkPath: "/home/user/.claude/skills/review",
-			Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+			Scope: nd.ScopeGlobal, Origin: nd.OriginManual,
+		},
 	}
 
 	engine := deploy.New(store, testAgent(), t.TempDir())
@@ -793,6 +810,88 @@ func TestPruneBackups(t *testing.T) {
 	}
 }
 
+func TestDeploy_RelativeSymlink(t *testing.T) {
+	store := newMockStore()
+	ag := testAgent()
+	engine := deploy.New(store, ag, t.TempDir())
+
+	var captured []symCall
+	engine.SetSymlink(func(oldname, newname string) error {
+		captured = append(captured, symCall{oldname, newname})
+		return nil
+	})
+	engine.SetLstat(func(string) (os.FileInfo, error) { return nil, os.ErrNotExist })
+	engine.SetMkdirAll(func(string, os.FileMode) error { return nil })
+
+	req := deploy.DeployRequest{
+		Asset: asset.Asset{
+			Identity:   asset.Identity{SourceID: "src", Type: nd.AssetSkill, Name: "review"},
+			SourcePath: "/home/user/.claude/skills/review-source",
+			IsDir:      true,
+		},
+		Scope:    nd.ScopeGlobal,
+		Origin:   nd.OriginManual,
+		Strategy: nd.SymlinkRelative,
+	}
+
+	result, err := engine.Deploy(req)
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 symlink call, got %d", len(captured))
+	}
+	// The target passed to symlink must not be an absolute path
+	if filepath.IsAbs(captured[0].oldname) {
+		t.Errorf("expected relative symlink target, got absolute: %q", captured[0].oldname)
+	}
+	// Strategy must be recorded on the deployment
+	if result.Deployment.Strategy != nd.SymlinkRelative {
+		t.Errorf("expected Strategy=%q in deployment, got %q", nd.SymlinkRelative, result.Deployment.Strategy)
+	}
+}
+
+func TestDeploy_AbsoluteSymlink(t *testing.T) {
+	store := newMockStore()
+	ag := testAgent()
+	engine := deploy.New(store, ag, t.TempDir())
+
+	var captured []symCall
+	engine.SetSymlink(func(oldname, newname string) error {
+		captured = append(captured, symCall{oldname, newname})
+		return nil
+	})
+	engine.SetLstat(func(string) (os.FileInfo, error) { return nil, os.ErrNotExist })
+	engine.SetMkdirAll(func(string, os.FileMode) error { return nil })
+
+	req := deploy.DeployRequest{
+		Asset: asset.Asset{
+			Identity:   asset.Identity{SourceID: "src", Type: nd.AssetSkill, Name: "review"},
+			SourcePath: "/sources/skills/review",
+			IsDir:      true,
+		},
+		Scope:    nd.ScopeGlobal,
+		Origin:   nd.OriginManual,
+		Strategy: nd.SymlinkAbsolute,
+	}
+
+	result, err := engine.Deploy(req)
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 symlink call, got %d", len(captured))
+	}
+	// The target passed to symlink must be the original absolute source path
+	if captured[0].oldname != "/sources/skills/review" {
+		t.Errorf("expected absolute source path as symlink target, got %q", captured[0].oldname)
+	}
+	// Strategy must be recorded on the deployment
+	if result.Deployment.Strategy != nd.SymlinkAbsolute {
+		t.Errorf("expected Strategy=%q in deployment, got %q", nd.SymlinkAbsolute, result.Deployment.Strategy)
+	}
+}
+
 // --- SnapshotSaver tests ---
 
 type mockSnapshotSaver struct {
@@ -817,9 +916,11 @@ func TestDeployBulkTriggersAutoSnapshot(t *testing.T) {
 
 	// Seed an existing deployment so the snapshot captures it
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "existing",
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "existing",
 			SourcePath: "/a", LinkPath: "/b", Scope: nd.ScopeGlobal,
-			Origin: nd.OriginManual},
+			Origin: nd.OriginManual,
+		},
 	}
 
 	eng.SetSymlink(func(_, _ string) error { return nil })
@@ -827,8 +928,10 @@ func TestDeployBulkTriggersAutoSnapshot(t *testing.T) {
 	eng.SetMkdirAll(func(_ string, _ os.FileMode) error { return nil })
 
 	reqs := []deploy.DeployRequest{
-		{Asset: asset.Asset{Identity: asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "new"},
-			SourcePath: "/src/skills/new"}, Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+		{Asset: asset.Asset{
+			Identity:   asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "new"},
+			SourcePath: "/src/skills/new",
+		}, Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
 	}
 	_, err := eng.DeployBulk(reqs)
 	if err != nil {
@@ -852,16 +955,20 @@ func TestRemoveBulkTriggersAutoSnapshot(t *testing.T) {
 	eng.SetSnapshotSaver(saver)
 
 	store.state.Deployments = []state.Deployment{
-		{SourceID: "s", AssetType: nd.AssetSkill, AssetName: "target",
+		{
+			SourceID: "s", AssetType: nd.AssetSkill, AssetName: "target",
 			SourcePath: "/a", LinkPath: "/b", Scope: nd.ScopeGlobal,
-			Origin: nd.OriginManual},
+			Origin: nd.OriginManual,
+		},
 	}
 
 	eng.SetRemove(func(_ string) error { return nil })
 
 	reqs := []deploy.RemoveRequest{
-		{Identity: asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "target"},
-			Scope: nd.ScopeGlobal},
+		{
+			Identity: asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "target"},
+			Scope:    nd.ScopeGlobal,
+		},
 	}
 	_, err := eng.RemoveBulk(reqs)
 	if err != nil {
@@ -884,8 +991,10 @@ func TestBulkWorksWithoutSnapshotSaver(t *testing.T) {
 	eng.SetMkdirAll(func(_ string, _ os.FileMode) error { return nil })
 
 	reqs := []deploy.DeployRequest{
-		{Asset: asset.Asset{Identity: asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "x"},
-			SourcePath: "/src/skills/x"}, Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+		{Asset: asset.Asset{
+			Identity:   asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "x"},
+			SourcePath: "/src/skills/x",
+		}, Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
 	}
 	_, err := eng.DeployBulk(reqs)
 	if err != nil {
@@ -906,8 +1015,10 @@ func TestAutoSnapshotFailureDoesNotBlockBulk(t *testing.T) {
 	eng.SetMkdirAll(func(_ string, _ os.FileMode) error { return nil })
 
 	reqs := []deploy.DeployRequest{
-		{Asset: asset.Asset{Identity: asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "x"},
-			SourcePath: "/src/skills/x"}, Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
+		{Asset: asset.Asset{
+			Identity:   asset.Identity{SourceID: "s", Type: nd.AssetSkill, Name: "x"},
+			SourcePath: "/src/skills/x",
+		}, Scope: nd.ScopeGlobal, Origin: nd.OriginManual},
 	}
 	result, err := eng.DeployBulk(reqs)
 	if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,15 +18,16 @@ type DeploymentState struct {
 
 // Deployment represents a single managed symlink.
 type Deployment struct {
-	SourceID    string          `yaml:"source_id"                json:"source_id"`
-	AssetType   nd.AssetType    `yaml:"asset_type"               json:"asset_type"`
-	AssetName   string          `yaml:"asset_name"               json:"asset_name"`
-	SourcePath  string          `yaml:"source_path"              json:"source_path"`
-	LinkPath    string          `yaml:"link_path"                json:"link_path"`
-	Scope       nd.Scope        `yaml:"scope"                    json:"scope"`
-	ProjectPath string          `yaml:"project_path,omitempty"   json:"project_path,omitempty"`
-	Origin      nd.DeployOrigin `yaml:"origin"                   json:"origin"`
-	DeployedAt  time.Time       `yaml:"deployed_at"              json:"deployed_at"`
+	SourceID    string             `yaml:"source_id"                json:"source_id"`
+	AssetType   nd.AssetType       `yaml:"asset_type"               json:"asset_type"`
+	AssetName   string             `yaml:"asset_name"               json:"asset_name"`
+	SourcePath  string             `yaml:"source_path"              json:"source_path"`
+	LinkPath    string             `yaml:"link_path"                json:"link_path"`
+	Scope       nd.Scope           `yaml:"scope"                    json:"scope"`
+	ProjectPath string             `yaml:"project_path,omitempty"   json:"project_path,omitempty"`
+	Origin      nd.DeployOrigin    `yaml:"origin"                   json:"origin"`
+	Strategy    nd.SymlinkStrategy `yaml:"strategy,omitempty"       json:"strategy,omitempty"`
+	DeployedAt  time.Time          `yaml:"deployed_at"              json:"deployed_at"`
 }
 
 // Identity returns the asset identity for this deployment.


### PR DESCRIPTION
## Summary

Closes 4 Should-Have FR gaps identified during a systematic audit of the spec against the CLI implementation:

- **FR-009a (Relative symlinks):** Added `--relative`/`--absolute` CLI flags to `nd deploy` (mutually exclusive). Wired `SymlinkStrategy` end-to-end through the deploy engine using `filepath.Rel`. Strategy resolution follows standard precedence: flag > config > default (absolute). Strategy is persisted in the deployment state record.
- **FR-016c (Context `_meta.yaml` display):** The scanner already loaded `_meta.yaml` into `Asset.Meta`, but `nd list` didn't surface it. Added `Description` and `Tags` fields to the list output for both human and JSON formats.
- **FR-044 (`--version` flag):** `nd version` subcommand worked, but `nd --version` did not. Set `rootCmd.Version` via Cobra's built-in mechanism.
- **FR-033 (Custom deploy locations):** Verified already functional via `AgentOverride` config — no changes needed.

## Test plan

- [x] 8 new tests added (2 deploy engine, 2 deploy CLI, 2 list CLI, 1 root CLI, 1 JSON list)
- [x] All 19 packages pass (`go test ./...`)
- [x] `gofumpt` formatting applied
- [x] Clean build (`go build ./...`)

## Should-Have FR scorecard after this PR

| Status | Count |
|--------|-------|
| Fully implemented (non-TUI) | **12 of 13** |
| TUI-only (blocked on rework) | 7 |
| Remaining gap | FR-029a auto-snapshots (needs verification) |