### PR TITLE
docs(site): add section content, navigation, and about page

### DIFF
--- a/site/content/docs/about.md
+++ b/site/content/docs/about.md
@@ -3,7 +3,7 @@ title: About
 weight: -1
 ---
 
-**nd** (Napoleon Dynamite) is a CLI tool for managing coding agent assets — skills, agents, commands, output styles, rules, context files, plugins, and hooks — via symlink deployment.
+**nd** (Napoleon Dynamite) is a CLI tool for managing coding agent assets — skills, agents, commands, output-styles, rules, context files, plugins, and hooks — via symlink deployment.
 
 ## How it works
 

--- a/site/content/docs/reference/_index.md
+++ b/site/content/docs/reference/_index.md
@@ -62,4 +62,8 @@ Complete reference for every nd command, including flags, options, and usage exa
   {{< card link="nd_settings_edit" title="nd settings edit" subtitle="Open config in editor" >}}
   {{< card link="nd_version" title="nd version" subtitle="Print nd version" >}}
   {{< card link="nd_uninstall" title="nd uninstall" subtitle="Remove all nd symlinks" >}}
+  {{< card link="nd_completion" title="nd completion" subtitle="Generate shell completion scripts" >}}
+  {{< card link="nd_completion_bash" title="nd completion bash" subtitle="Bash completion script" >}}
+  {{< card link="nd_completion_fish" title="nd completion fish" subtitle="Fish completion script" >}}
+  {{< card link="nd_completion_zsh" title="nd completion zsh" subtitle="Zsh completion script" >}}
 {{< /cards >}}


### PR DESCRIPTION
## Summary

Builds on the live docs site infrastructure from #11 by adding navigable content to the section landing pages and configuring site-wide navigation.

- **Section indexes**: Guide and Reference `_index.md` pages now show card grids linking to all child pages instead of blank sections
- **Reference command list**: All 32 commands organized into 5 groups (Core, Profile, Snapshot, Source, Other) with subtitle descriptions
- **About page**: New page at the top of the sidebar (`weight: -1`) with project overview, install instructions, and links
- **Navigation**: Navbar menu (Documentation, About, GitHub, Search) and sidebar extras (GitHub, Go Docs)
- **Landing page**: Cleaner subtitle, shell code fence for install command, icon-annotated feature cards, better spacing
- **Sidebar defaults**: Guide and Reference sections expanded by default via `sidebar.open: true`

## Test plan

- [ ] Run `cd site && hugo build --gc --minify` — should produce 58 pages with no errors
- [ ] Verify landing page renders hero, install code fence, and 3 feature cards
- [ ] Verify docs hub shows card links to Guides and Command Reference
- [ ] Verify guide index shows 6 card tiles
- [ ] Verify reference index shows 32 commands in 5 grouped sections
- [ ] Verify About page appears at top of sidebar, above Guides
- [ ] Verify navbar shows Documentation, About, GitHub, and Search
- [ ] Verify sidebar shows "More" separator with GitHub and Go Docs links