### PR TITLE
feat(updater): show brew update notice when a newer version is available

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/armstrongl/nd/internal/nd"
 	"github.com/armstrongl/nd/internal/tui"
+	"github.com/armstrongl/nd/internal/updater"
 	"github.com/armstrongl/nd/internal/version"
 )
 
@@ -25,6 +26,9 @@ func NewRootCmd(app *App) *cobra.Command {
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return persistentPreRun(cmd, app)
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			return persistentPostRun(cmd, app)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Launch TUI when running interactively with no flags that conflict.
@@ -94,7 +98,32 @@ func Execute() int {
 	return nd.ExitSuccess
 }
 
-// persistentPreRun resolves config path and scope before any command runs.
+// persistentPostRun runs after every successful command. It shows an update
+// notice when a newer version is available and the user installed nd via
+// Homebrew, then kicks off a background cache refresh.
+func persistentPostRun(cmd *cobra.Command, app *App) error {
+	if app.Quiet || app.JSON {
+		return nil
+	}
+	if version.Version == "dev" || !updater.IsBrewInstall() {
+		return nil
+	}
+	cacheDir := filepath.Dir(app.ConfigPath)
+	if cacheDir == "" || cacheDir == "." {
+		return nil
+	}
+	latest, _ := updater.CheckCached(cacheDir)
+	if latest != "" && updater.IsNewer(latest, version.Version) {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"\nA new version of nd is available: v%s (you have %s)\nTo update: brew upgrade nd\n\n",
+			latest, version.Version,
+		)
+	}
+	updater.RefreshAsync(cacheDir)
+	return nil
+}
+
+
 func persistentPreRun(cmd *cobra.Command, app *App) error {
 	// Expand ~ in config path
 	if strings.HasPrefix(app.ConfigPath, "~/") {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -37,6 +37,18 @@ Verify the installation:
 nd version
 ```
 
+## Update nd
+
+If you installed nd via Homebrew, update it with:
+
+```shell
+brew update && brew upgrade nd
+```
+
+If `brew upgrade nd` installs an older version, your local tap index may be stale. Run `brew update` first to refresh it, then upgrade again.
+
+nd will also notify you when a newer version is available — the message appears after a command completes, once per day.
+
 ## 2. Initialize
 
 Create the nd configuration directory and default config:

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,128 @@
+package updater
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	cacheFileName = "update-check.json"
+	cacheMaxAge   = 24 * time.Hour
+	githubAPIURL  = "https://api.github.com/repos/armstrongl/nd/releases/latest"
+	checkTimeout  = 5 * time.Second
+)
+
+type cacheEntry struct {
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+// IsBrewInstall reports whether the running binary was installed via Homebrew.
+// It resolves the real executable path (following symlinks) and checks for
+// Homebrew path patterns on macOS and Linux.
+func IsBrewInstall() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return false
+	}
+	lower := strings.ToLower(exe)
+	return strings.Contains(lower, "/cellar/") || strings.Contains(lower, "/homebrew/")
+}
+
+// CheckCached returns the latest version string from the on-disk cache if the
+// cache exists and is younger than 24 hours. Returns an empty string (not an
+// error) when the cache is missing, stale, or unreadable.
+func CheckCached(cacheDir string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(cacheDir, cacheFileName))
+	if err != nil {
+		return "", nil
+	}
+	var entry cacheEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return "", nil
+	}
+	if time.Since(entry.CheckedAt) > cacheMaxAge {
+		return "", nil
+	}
+	return entry.LatestVersion, nil
+}
+
+// RefreshAsync fetches the latest release version from GitHub in a background
+// goroutine and persists the result to the cache file. Errors are discarded
+// silently so this never blocks or fails a command.
+func RefreshAsync(cacheDir string) {
+	go func() {
+		latest, err := fetchLatestVersion()
+		if err != nil || latest == "" {
+			return
+		}
+		entry := cacheEntry{
+			LatestVersion: latest,
+			CheckedAt:     time.Now().UTC(),
+		}
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return
+		}
+		_ = os.WriteFile(filepath.Join(cacheDir, cacheFileName), data, 0o600)
+	}()
+}
+
+// IsNewer reports whether candidate is a strictly newer semantic version than
+// current. Both strings may optionally carry a "v" prefix.
+func IsNewer(candidate, current string) bool {
+	cv := parseSemver(candidate)
+	cc := parseSemver(current)
+	for i := range cv {
+		if cv[i] > cc[i] {
+			return true
+		}
+		if cv[i] < cc[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func fetchLatestVersion() (string, error) {
+	client := &http.Client{Timeout: checkTimeout}
+	resp, err := client.Get(githubAPIURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+	var payload struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(payload.TagName, "v"), nil
+}
+
+func parseSemver(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	var out [3]int
+	for i, p := range parts {
+		if i >= 3 {
+			break
+		}
+		p = strings.SplitN(p, "-", 2)[0] // strip pre-release suffix
+		out[i], _ = strconv.Atoi(p)
+	}
+	return out
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,109 @@
+package updater
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIsNewer(t *testing.T) {
+	t.Helper()
+	tests := []struct {
+		candidate string
+		current   string
+		want      bool
+	}{
+		{"0.4.0", "0.3.0", true},
+		{"v0.4.0", "v0.3.0", true},
+		{"0.3.0", "0.3.0", false},
+		{"0.2.0", "0.3.0", false},
+		{"1.0.0", "0.9.9", true},
+		{"0.3.1", "0.3.0", true},
+		{"0.3.0", "0.3.1", false},
+		// dev builds report 0.0.0 — a real release should never appear newer
+		{"0.0.0", "dev", false},
+		{"0.1.0", "dev", true},
+		// pre-release suffix stripped
+		{"0.4.0-beta", "0.3.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.candidate+"_vs_"+tt.current, func(t *testing.T) {
+			got := IsNewer(tt.candidate, tt.current)
+			if got != tt.want {
+				t.Errorf("IsNewer(%q, %q) = %v, want %v", tt.candidate, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckCached_missing(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	got, err := CheckCached(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for missing cache, got %q", got)
+	}
+}
+
+func TestCheckCached_fresh(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	writeCache(t, dir, "0.5.0", time.Now().UTC())
+
+	got, err := CheckCached(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "0.5.0" {
+		t.Errorf("expected %q, got %q", "0.5.0", got)
+	}
+}
+
+func TestCheckCached_stale(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	writeCache(t, dir, "0.5.0", time.Now().UTC().Add(-25*time.Hour))
+
+	got, err := CheckCached(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for stale cache, got %q", got)
+	}
+}
+
+func TestCheckCached_corrupt(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, cacheFileName)
+	if err := os.WriteFile(path, []byte("not valid json"), 0o600); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	got, err := CheckCached(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for corrupt cache, got %q", got)
+	}
+}
+
+// writeCache is a test helper that writes a cache entry to dir.
+func writeCache(t *testing.T, dir, version string, at time.Time) {
+	t.Helper()
+	entry := cacheEntry{LatestVersion: version, CheckedAt: at}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, cacheFileName), data, 0o600); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Adds a lightweight update check that notifies Homebrew users when a newer version of nd is available.

## How it works

- **`internal/updater`** (new package):
  - `IsBrewInstall()` — detects Homebrew by resolving the real executable path and checking for `/cellar/` or `/homebrew/`
  - `CheckCached()` — reads a 24h cache from `~/.config/nd/update-check.json`; returns empty string if missing or stale
  - `RefreshAsync()` — fire-and-forget goroutine that hits the GitHub releases API and saves the result to cache
  - `IsNewer()` — semver comparison (strips `v` prefix and pre-release suffixes)

- **`cmd/root.go`** — `PersistentPostRunE` prints a notice to stderr after any successful command:
  ```
  A new version of nd is available: v0.4.0 (you have v0.3.0)
  To update: brew upgrade nd
  ```
  Suppressed when `--quiet` or `--json` is set. No-op in dev builds and non-Homebrew installs.

- **`docs/guide/getting-started.md`** — adds an "Update nd" section explaining `brew update && brew upgrade nd` and the automatic notice.

## Design notes

- Zero latency: the check reads only from the local cache; the network fetch happens in the background after the command finishes
- Once per day: cache TTL is 24 hours
- Brew-only: non-Homebrew installs (Go install, source build) see nothing
- Safe: all updater errors are silently discarded — this never fails a command