### PR TITLE
fix(ci): render staleness JSON in PR body

### DIFF
--- a/.github/workflows/docs-staleness.yml
+++ b/.github/workflows/docs-staleness.yml
@@ -38,6 +38,11 @@ jobs:
           python scripts/agents/check-staleness.py --dry-run > staleness-output.json
           if [ -s staleness-output.json ] && [ "$(cat staleness-output.json)" != "[]" ]; then
             echo "has_stale=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'json<<EOF'
+              cat staleness-output.json
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
             echo "Stale docs found:"
             cat staleness-output.json
           else
@@ -62,7 +67,7 @@ jobs:
             and merge this PR.
 
             ```json
-            $(cat staleness-output.json)
+            ${{ steps.staleness.outputs.json }}
             ```
           branch: agents/staleness-${{ github.run_id }}
           labels: agents-staleness


### PR DESCRIPTION
## Summary

Fixes the docs staleness workflow (ISSUE-006). Every staleness PR was showing the literal text `$(cat staleness-output.json)` in its body instead of the actual JSON report.

**Root cause:** `peter-evans/create-pull-request` `with:` parameters evaluate `${{ }}` expressions — they do not run shell command substitution. The `$(cat ...)` syntax is evaluated only inside `run:` blocks.

**Fix:** Emit the JSON as a step output via the `$GITHUB_OUTPUT` heredoc pattern in the existing `staleness` step, then reference it with `${{ steps.staleness.outputs.json }}` in the PR body.

## Changes

- `.github/workflows/docs-staleness.yml` — two changes:
  1. Add heredoc JSON output in the `has_stale=true` branch of the `Run staleness check` step
  2. Replace `$(cat staleness-output.json)` with `${{ steps.staleness.outputs.json }}` in the PR body

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a CI workflow change. The next staleness PR created after merging should show a valid JSON array in its body instead of the literal string `$(cat staleness-output.json)`.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Sonnet 4.6 via [Claude Code](https://claude.ai/claude-code)