### PR TITLE
feat(staleness): auto-resolve trivial staleness via commit-type triage

### DIFF
--- a/.github/workflows/docs-staleness.yml
+++ b/.github/workflows/docs-staleness.yml
@@ -35,9 +35,7 @@ jobs:
       - name: Run staleness check
         id: staleness
         run: |
-          cd scripts/agents
-          python check-staleness.py --repo-root ../.. --dry-run > ../../staleness-output.json
-          cd ../..
+          python scripts/agents/check-staleness.py --dry-run > staleness-output.json
 
           if [ -s staleness-output.json ] && [ "$(cat staleness-output.json)" != "[]" ]; then
             echo "has_stale=true" >> "$GITHUB_OUTPUT"
@@ -61,9 +59,7 @@ jobs:
         id: autobump
         if: steps.staleness.outputs.auto_count != '0'
         run: |
-          cd scripts/agents
-          BUMPED=$(python bump-validated.py --report ../../staleness-output.json)
-          cd ../..
+          BUMPED=$(python scripts/agents/bump-validated.py --report staleness-output.json)
           echo "bumped=$BUMPED" >> "$GITHUB_OUTPUT"
           echo "Auto-bumped: $BUMPED"
 
@@ -89,10 +85,7 @@ jobs:
 
       - name: Regenerate AGENTS.md index
         if: steps.staleness.outputs.has_stale == 'true'
-        run: |
-          cd scripts/agents
-          python build-index.py --staleness-report ../../review-report.json --agents-md ../../AGENTS.md
-          cd ../..
+        run: python scripts/agents/build-index.py --staleness-report review-report.json
 
       - name: Create pull request
         if: steps.staleness.outputs.has_stale == 'true'

--- a/scripts/agents/bump-validated.py
+++ b/scripts/agents/bump-validated.py
@@ -9,6 +9,7 @@ in each file's YAML frontmatter to today's date (or a date given via
 
 import argparse
 import json
+import os
 import re
 import sys
 from datetime import date
@@ -47,6 +48,11 @@ def main():
         help="Path to the staleness report JSON (default: staleness-report.json)",
     )
     parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Path to repo root for resolving report file paths (default: .)",
+    )
+    parser.add_argument(
         "--date",
         default=str(date.today()),
         help="Date to set lastValidated to (default: today)",
@@ -72,16 +78,16 @@ def main():
     for entry in report:
         if not entry.get("autoResolvable"):
             continue
-        filepath = entry["file"]
+        filepath = os.path.join(args.repo_root, entry["file"])
         if args.dry_run:
-            print(f"Would bump {filepath} → {args.date}", file=sys.stderr)
-            bumped.append(filepath)
+            print(f"Would bump {entry['file']} → {args.date}", file=sys.stderr)
+            bumped.append(entry["file"])
         else:
             if bump_last_validated(filepath, args.date):
-                bumped.append(filepath)
-                print(f"Bumped {filepath} → {args.date}", file=sys.stderr)
+                bumped.append(entry["file"])
+                print(f"Bumped {entry['file']} → {args.date}", file=sys.stderr)
             else:
-                print(f"Warning: no lastValidated found in {filepath}", file=sys.stderr)
+                print(f"Warning: no lastValidated found in {entry['file']}", file=sys.stderr)
 
     # Machine-readable output for workflow consumption
     print(json.dumps(bumped))

--- a/scripts/agents/check-staleness.py
+++ b/scripts/agents/check-staleness.py
@@ -130,8 +130,12 @@ def check_path_staleness(paths: list[str], last_validated: str, repo_root: str) 
 
     output = run_git_log(last_validated, paths, repo_root)
     if output:
-        commit_count = len(output.strip().split("\n"))
         classification = classify_log_output(output)
+        # Use the classified prefix counts (merge commits excluded)
+        # so the reported count matches the prefixes breakdown.
+        commit_count = sum(classification["prefixes"].values())
+        if commit_count == 0:
+            return None
         return {
             "reason": "paths",
             "detail": f"{commit_count} commit(s) touching tracked paths since {last_validated}",


### PR DESCRIPTION
## Summary

Enhances the docs staleness workflow to classify commits by conventional commit prefix and automatically bump `lastValidated` for docs whose tracked paths were only touched by internal commits (`fix`, `refactor`, `test`, `ci`, `chore`, `build`, `style`, `perf`).

## What changed

### `check-staleness.py`
- New `classify_commit()` and `classify_log_output()` functions parse conventional commit prefixes
- Report entries now include `autoResolvable` boolean and `prefixes` breakdown
- Path-only staleness with all-internal commits → `autoResolvable: true`
- Time-based staleness, `feat:`, `docs:`, or unknown prefixes → `autoResolvable: false`

### `bump-validated.py` (new)
- Reads the staleness report, filters `autoResolvable` entries, bumps `lastValidated` in frontmatter
- Outputs JSON array of bumped file paths for workflow consumption

### `docs-staleness.yml`
- Counts auto-resolvable vs review-needed docs
- Auto-bumps trivial staleness via `bump-validated.py`
- Passes only review-needed entries to AGENTS.md index regeneration
- PR body separates auto-resolved from needs-review counts
- When all docs are auto-resolved, PR says 'safe to merge'

## How it works in practice

**Before:** Every staleness PR required manual review of all flagged docs, even when the only commits were bug fixes or refactors that don't affect user-facing documentation.

**After:** The workflow classifies each commit. If a doc was only touched by internal commits (e.g., `fix(deploy): handle edge case`), it auto-bumps the date. Only docs touched by `feat:` or `docs:` commits get flagged for review.

Example: the staleness report we just resolved in PR #43 had 6 docs flagged. All were touched by `feat:` commits (builtin source, force-replace, agent filtering), so they would still need review. But if those had been `fix:` commits instead, the workflow would have auto-resolved all 6 with no human intervention.