### PR TITLE
refactor(tui): consolidate list rendering across screens

### DIFF
--- a/internal/tui/browse.go
+++ b/internal/tui/browse.go
@@ -25,12 +25,11 @@ type browseScreen struct {
 	styles Styles
 	isDark bool
 
-	assets    []*asset.Asset
-	deployed  map[string]bool
-	cursor    int
-	filter    string
-	filtering bool
-	notice    string // transient feedback (e.g. "already deployed")
+	assets   []*asset.Asset
+	deployed map[string]bool
+	cursor   int
+	filter   filterInput
+	notice   string // transient feedback (e.g. "already deployed")
 	err       error
 	loaded    bool
 
@@ -50,11 +49,11 @@ func (b *browseScreen) Title() string { return "Browse" }
 
 // InputActive returns true while the filter input is active,
 // suppressing global q/esc key handling.
-func (b *browseScreen) InputActive() bool { return b.filtering }
+func (b *browseScreen) InputActive() bool { return b.filter.active }
 
 // FullHelpItems returns step-specific help items for the browse screen.
 func (b *browseScreen) FullHelpItems() []HelpItem {
-	if b.filtering {
+	if b.filter.active {
 		return []HelpItem{
 			{"esc", "cancel"},
 			{"enter", "apply"},
@@ -112,8 +111,7 @@ func (b *browseScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		b.loaded = false
 		b.assets = nil
 		b.deployed = nil
-		b.filter = ""
-		b.filtering = false
+		b.filter = filterInput{}
 		b.cursor = 0
 		b.scroll = listScroll{}
 		return b, b.Init()
@@ -143,23 +141,8 @@ func (b *browseScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // handleKey processes keyboard input, routing filter keys vs navigation.
 func (b *browseScreen) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	if b.filtering {
-		switch msg.String() {
-		case "esc":
-			b.filter = ""
-			b.filtering = false
-		case "enter":
-			b.filtering = false
-		case "backspace":
-			if len(b.filter) > 0 {
-				b.filter = b.filter[:len(b.filter)-1]
-			}
-		default:
-			// Append printable characters to filter.
-			if msg.Text != "" {
-				b.filter += msg.Text
-			}
-		}
+	if b.filter.active {
+		b.filter.HandleKey(msg)
 		b.clampCursor()
 		return b, nil
 	}
@@ -174,7 +157,7 @@ func (b *browseScreen) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	case "/":
-		b.filtering = true
+		b.filter.active = true
 		return b, nil
 
 	case "j", "down":
@@ -227,15 +210,9 @@ func (b *browseScreen) View() tea.View {
 	var buf strings.Builder
 
 	// Filter bar when active.
-	if b.filtering || b.filter != "" {
-		indicator := " "
-		if b.filtering {
-			indicator = "_"
-		}
-		fmt.Fprintf(&buf, "  %s %s%s\n\n",
-			b.styles.Subtle.Render("/"),
-			b.filter,
-			indicator)
+	if filterBar := b.filter.Render(b.styles); filterBar != "" {
+		buf.WriteString(filterBar)
+		buf.WriteString("\n")
 	}
 
 	if len(visible) == 0 {
@@ -297,7 +274,7 @@ func (b *browseScreen) View() tea.View {
 
 	total := len(b.assets)
 	shown := len(visible)
-	if b.filter != "" {
+	if b.filter.text != "" {
 		fmt.Fprintf(&buf, "\n  %s",
 			b.styles.Subtle.Render(fmt.Sprintf("%d of %d  · / to filter", shown, total)))
 	} else {
@@ -309,25 +286,17 @@ func (b *browseScreen) View() tea.View {
 }
 
 // contentHeight returns the number of list rows that fit in the terminal.
-// When height is unknown (0), it returns listScrollUnlimited so all assets
-// are visible without windowing (matching pre-scroll behaviour in tests).
+// Browse has extra chrome beyond the standard 4 lines (summary footer,
+// optional filter bar, optional notice).
 func (b *browseScreen) contentHeight() int {
-	if b.height == 0 {
-		return listScrollUnlimited
-	}
-	h := b.height
-	h -= 4 // root chrome: header + 2 blank separators + helpbar
-	h -= 2 // summary footer: blank line + summary line
-	if b.filtering || b.filter != "" {
-		h -= 2 // filter bar + blank line below it
+	extra := 4 + 2 // root chrome + summary footer
+	if b.filter.active || b.filter.text != "" {
+		extra += 2 // filter bar + blank line below it
 	}
 	if b.notice != "" {
-		h -= 2 // transient notice + blank line before it
+		extra += 2 // transient notice + blank line before it
 	}
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return ContentHeight(b.height, extra)
 }
 
 // clampCursor ensures the cursor stays within the visible asset list bounds
@@ -346,15 +315,12 @@ func (b *browseScreen) clampCursor() {
 
 // visibleAssets returns the filtered asset list (or all if no filter set).
 func (b *browseScreen) visibleAssets() []*asset.Asset {
-	if b.filter == "" {
+	if b.filter.text == "" {
 		return b.assets
 	}
-	lower := strings.ToLower(b.filter)
 	var out []*asset.Asset
 	for _, a := range b.assets {
-		if strings.Contains(strings.ToLower(a.Name), lower) ||
-			strings.Contains(strings.ToLower(string(a.Type)), lower) ||
-			strings.Contains(strings.ToLower(a.SourceID), lower) {
+		if b.filter.MatchesAny(a.Name, string(a.Type), a.SourceID) {
 			out = append(out, a)
 		}
 	}

--- a/internal/tui/browse.go
+++ b/internal/tui/browse.go
@@ -143,7 +143,7 @@ func (b *browseScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (b *browseScreen) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if b.filter.active {
 		b.filter.HandleKey(msg)
-		b.clampCursor()
+		b.clampCursor() // always clamp: browse re-filters live in visibleAssets()
 		return b, nil
 	}
 

--- a/internal/tui/browse_test.go
+++ b/internal/tui/browse_test.go
@@ -26,7 +26,7 @@ func TestBrowseScreen_Title(t *testing.T) {
 
 func TestBrowseScreen_InputActive_WhenFiltering(t *testing.T) {
 	s := newBrowseScreen(newMockServices(), NewStyles(true), true)
-	s.filtering = true
+	s.filter.active = true
 	if !s.InputActive() {
 		t.Fatal("InputActive() = false while filtering, want true")
 	}
@@ -34,7 +34,7 @@ func TestBrowseScreen_InputActive_WhenFiltering(t *testing.T) {
 
 func TestBrowseScreen_InputActive_WhenNotFiltering(t *testing.T) {
 	s := newBrowseScreen(newMockServices(), NewStyles(true), true)
-	s.filtering = false
+	s.filter.active = false
 	if s.InputActive() {
 		t.Fatal("InputActive() = true when not filtering, want false")
 	}
@@ -104,7 +104,7 @@ func TestBrowseScreen_FilterNarrowsResults(t *testing.T) {
 	s.Update(browseLoadedMsg{assets: idx.All()})
 
 	// Apply filter "deploy"
-	s.filter = "deploy"
+	s.filter.text = "deploy"
 
 	v := s.View()
 	if !strings.Contains(v.Content, "deploy-helper") {
@@ -121,48 +121,48 @@ func TestBrowseScreen_SlashEntersFilterMode(t *testing.T) {
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: '/', Text: "/"}))
 
-	if !s.filtering {
+	if !s.filter.active {
 		t.Fatal("pressing / should enter filter mode")
 	}
 }
 
 func TestBrowseScreen_EscExitsFilterMode(t *testing.T) {
 	s := newBrowseScreen(newMockServices(), NewStyles(true), true)
-	s.filtering = true
-	s.filter = "foo"
+	s.filter.active = true
+	s.filter.text = "foo"
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEsc}))
 
-	if s.filtering {
+	if s.filter.active {
 		t.Fatal("esc should exit filter mode")
 	}
-	if s.filter != "" {
-		t.Fatalf("esc should clear filter, got: %q", s.filter)
+	if s.filter.text != "" {
+		t.Fatalf("esc should clear filter, got: %q", s.filter.text)
 	}
 }
 
 func TestBrowseScreen_FilterCharsAppend(t *testing.T) {
 	s := newBrowseScreen(newMockServices(), NewStyles(true), true)
-	s.filtering = true
+	s.filter.active = true
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: 'a', Text: "a"}))
 	s.Update(tea.KeyPressMsg(tea.Key{Code: 'b', Text: "b"}))
 	s.Update(tea.KeyPressMsg(tea.Key{Code: 'c', Text: "c"}))
 
-	if s.filter != "abc" {
-		t.Fatalf("filter should be %q, got %q", "abc", s.filter)
+	if s.filter.text != "abc" {
+		t.Fatalf("filter should be %q, got %q", "abc", s.filter.text)
 	}
 }
 
 func TestBrowseScreen_BackspaceDeletesFilterChar(t *testing.T) {
 	s := newBrowseScreen(newMockServices(), NewStyles(true), true)
-	s.filtering = true
-	s.filter = "foo"
+	s.filter.active = true
+	s.filter.text = "foo"
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
 
-	if s.filter != "fo" {
-		t.Fatalf("backspace should remove last char, got %q", s.filter)
+	if s.filter.text != "fo" {
+		t.Fatalf("backspace should remove last char, got %q", s.filter.text)
 	}
 }
 
@@ -278,7 +278,7 @@ func TestBrowseScreen_CursorResetOnFilterChange(t *testing.T) {
 
 	// Move cursor to 2, then apply filter that shows fewer items.
 	s.cursor = 2
-	s.filtering = true
+	s.filter.active = true
 	s.Update(tea.KeyPressMsg(tea.Key{Code: 'b', Text: "b"})) // filter = "b" -> only "bravo"
 
 	if s.cursor >= len(s.visibleAssets()) {
@@ -366,7 +366,7 @@ func TestBrowseScreen_FullHelpItems_Default(t *testing.T) {
 
 func TestBrowseScreen_FullHelpItems_Filtering(t *testing.T) {
 	s := newBrowseScreen(newMockServices(), NewStyles(true), true)
-	s.filtering = true
+	s.filter.active = true
 	items := s.FullHelpItems()
 
 	if len(items) != 3 {
@@ -411,16 +411,16 @@ func TestBrowseScreen_ErrorPathRendersError(t *testing.T) {
 
 func TestBrowseScreen_EnterInFilterModePreservesFilter(t *testing.T) {
 	s := browseSeedAssets(t, 3, nil)
-	s.filtering = true
-	s.filter = "asset"
+	s.filter.active = true
+	s.filter.text = "asset"
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
 
-	if s.filtering {
+	if s.filter.active {
 		t.Fatal("enter should exit filter mode")
 	}
-	if s.filter != "asset" {
-		t.Fatalf("enter should preserve filter text, got %q", s.filter)
+	if s.filter.text != "asset" {
+		t.Fatalf("enter should preserve filter text, got %q", s.filter.text)
 	}
 }
 
@@ -431,7 +431,7 @@ func TestBrowseScreen_KeysIgnoredBeforeLoad(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("keys before load should produce nil cmd")
 	}
-	if s.filtering {
+	if s.filter.active {
 		t.Fatal("/ before load should not enter filter mode")
 	}
 }
@@ -527,8 +527,8 @@ func TestBrowseScreen_NoIndicatorsWhenAllFit(t *testing.T) {
 
 func TestBrowseScreen_ScopeSwitchedMsg_ResetsAndReloads(t *testing.T) {
 	s := browseSeedAssets(t, 3, nil)
-	s.filtering = true
-	s.filter = "test"
+	s.filter.active = true
+	s.filter.text = "test"
 	s.cursor = 2
 
 	if !s.loaded {
@@ -546,10 +546,10 @@ func TestBrowseScreen_ScopeSwitchedMsg_ResetsAndReloads(t *testing.T) {
 	if s.deployed != nil {
 		t.Error("deployed should be nil after ScopeSwitchedMsg")
 	}
-	if s.filter != "" {
-		t.Errorf("filter should be empty, got %q", s.filter)
+	if s.filter.text != "" {
+		t.Errorf("filter should be empty, got %q", s.filter.text)
 	}
-	if s.filtering {
+	if s.filter.active {
 		t.Error("filtering should be false after ScopeSwitchedMsg")
 	}
 	if s.cursor != 0 {

--- a/internal/tui/deploy.go
+++ b/internal/tui/deploy.go
@@ -517,20 +517,14 @@ func deployBulkCmd(deployer func([]deploy.DeployRequest) (*deploy.BulkDeployResu
 // updateResult handles key presses at the result step.
 // H4: Only "enter" reaches here — esc/q are intercepted by root model.
 func (ds *deployScreen) updateResult(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Eagerly populate resultLines so scroll keys work before the first render.
 	if len(ds.resultLines) == 0 {
 		ds.resultLines = splitLines(ds.buildResultContent())
 	}
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
-		switch keyMsg.String() {
-		case "j", "down":
-			ds.scroll.ScrollDown(len(ds.resultLines), ds.contentHeight())
+		switch HandleScrollKeys(keyMsg, &ds.scroll, len(ds.resultLines), ds.contentHeight()) {
+		case scrollKeyHandled:
 			return ds, nil
-		case "k", "up":
-			ds.scroll.ScrollUp()
-			return ds, nil
-		case "enter":
-			// M7: PopToRootMsg (matching remove screen behavior)
+		case scrollKeyPopToRoot:
 			return ds, tea.Batch(
 				func() tea.Msg { return PopToRootMsg{} },
 				func() tea.Msg { return RefreshHeaderMsg{} },
@@ -541,14 +535,7 @@ func (ds *deployScreen) updateResult(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (ds *deployScreen) contentHeight() int {
-	if ds.height == 0 {
-		return listScrollUnlimited
-	}
-	h := ds.height - 4
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return ContentHeight(ds.height, 4)
 }
 
 // buildResultContent renders the full deployment result as a string.
@@ -605,31 +592,7 @@ func (ds *deployScreen) viewResult() tea.View {
 	if len(ds.resultLines) == 0 {
 		ds.resultLines = splitLines(ds.buildResultContent())
 	}
-
-	lines := ds.resultLines
-	pageSize := ds.contentHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.
-	if ds.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if ds.scroll.MoreBelow(len(lines), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := ds.scroll.Window(len(lines), pageSize)
-
-	var b strings.Builder
-	if above := ds.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(ds.styles, "↑", above))
-	}
-	b.WriteString(strings.Join(lines[start:end], "\n"))
-	if below := ds.scroll.MoreBelow(len(lines), pageSize); below > 0 {
-		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(ds.styles, "↓", below))
-	}
-	return tea.NewView(b.String())
+	return tea.NewView(RenderScrolledLines(ds.styles, &ds.scroll, ds.resultLines, ds.contentHeight()))
 }
 
 // --- Conflict resolution ---

--- a/internal/tui/doctor.go
+++ b/internal/tui/doctor.go
@@ -57,8 +57,9 @@ type doctorScreen struct {
 	err        error
 
 	// issue list scrolling (confirm step)
-	height int
-	scroll listScroll
+	issueLines []string // pre-rendered issue lines for RenderScrolledLines
+	height     int
+	scroll     listScroll
 }
 
 func newDoctorScreen(svc Services, styles Styles, isDark bool) *doctorScreen {
@@ -167,6 +168,7 @@ func (d *doctorScreen) handleChecked(msg doctorCheckedMsg) (tea.Model, tea.Cmd) 
 	}
 
 	d.issues = msg.issues
+	d.issueLines = d.buildIssueLines()
 	d.scroll = listScroll{}
 	d.step = doctorConfirm
 
@@ -215,7 +217,7 @@ func (d *doctorScreen) updateConfirm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
 		switch keyMsg.String() {
 		case "j", "down":
-			d.scroll.ScrollDown(len(d.issues), d.issueListHeight())
+			d.scroll.ScrollDown(len(d.issueLines), d.issueListHeight())
 			return d, nil
 		case "k", "up":
 			d.scroll.ScrollUp()
@@ -281,35 +283,7 @@ func (d *doctorScreen) viewConfirm() tea.View {
 	fmt.Fprintf(&b, "  %s %d issue(s) found:\n\n",
 		d.styles.Warning.Render(GlyphBroken), len(d.issues))
 
-	pageSize := d.issueListHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.
-	if d.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if d.scroll.MoreBelow(len(d.issues), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := d.scroll.Window(len(d.issues), pageSize)
-
-	if above := d.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(d.styles, "↑", above))
-	}
-
-	for _, issue := range d.issues[start:end] {
-		glyph := healthGlyph(issue.Status)
-		styled := styleGlyphWith(d.styles, glyph, issue.Status)
-		fmt.Fprintf(&b, "    %s  %-20s  %s\n",
-			styled, issue.Deployment.AssetName,
-			d.styles.Subtle.Render(issue.Detail))
-	}
-
-	if below := d.scroll.MoreBelow(len(d.issues), pageSize); below > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(d.styles, "↓", below))
-	}
+	b.WriteString(RenderScrolledLines(d.styles, &d.scroll, d.issueLines, d.issueListHeight()))
 
 	if d.confirmForm != nil {
 		b.WriteString("\n")
@@ -317,6 +291,19 @@ func (d *doctorScreen) viewConfirm() tea.View {
 	}
 
 	return tea.NewView(b.String())
+}
+
+// buildIssueLines pre-renders each issue as a single line for RenderScrolledLines.
+func (d *doctorScreen) buildIssueLines() []string {
+	lines := make([]string, len(d.issues))
+	for i, issue := range d.issues {
+		glyph := healthGlyph(issue.Status)
+		styled := styleGlyphWith(d.styles, glyph, issue.Status)
+		lines[i] = fmt.Sprintf("    %s  %-20s  %s",
+			styled, issue.Deployment.AssetName,
+			d.styles.Subtle.Render(issue.Detail))
+	}
+	return lines
 }
 
 func (d *doctorScreen) viewDone() tea.View {

--- a/internal/tui/listview.go
+++ b/internal/tui/listview.go
@@ -1,0 +1,139 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// RenderScrolledLines renders pre-rendered lines within a scrollable viewport,
+// adding ↑/↓ indicators when items are hidden above or below. It reserves
+// rows for scroll indicators so they don't push content past the budget.
+func RenderScrolledLines(styles Styles, scroll *listScroll, lines []string, pageSize int) string {
+	if len(lines) == 0 {
+		return ""
+	}
+
+	// Reserve rows for scroll indicators.
+	if scroll.MoreAbove() > 0 {
+		pageSize--
+	}
+	if scroll.MoreBelow(len(lines), pageSize) > 0 {
+		pageSize--
+	}
+	if pageSize < 1 {
+		pageSize = 1
+	}
+	start, end := scroll.Window(len(lines), pageSize)
+
+	var b strings.Builder
+	if above := scroll.MoreAbove(); above > 0 {
+		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(styles, "↑", above))
+	}
+	b.WriteString(strings.Join(lines[start:end], "\n"))
+	if below := scroll.MoreBelow(len(lines), pageSize); below > 0 {
+		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(styles, "↓", below))
+	}
+	return b.String()
+}
+
+// ContentHeight returns the number of content rows that fit in the terminal
+// after subtracting chrome lines. Returns listScrollUnlimited when the
+// terminal height is unknown (0), disabling windowing.
+func ContentHeight(termHeight, chromeLines int) int {
+	if termHeight == 0 {
+		return listScrollUnlimited
+	}
+	h := termHeight - chromeLines
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+// scrollKeyResult indicates how HandleScrollKeys resolved a key press.
+type scrollKeyResult int
+
+const (
+	scrollKeyUnhandled scrollKeyResult = iota
+	scrollKeyHandled
+	scrollKeyPopToRoot
+)
+
+// HandleScrollKeys processes j/k/enter keys for scrollable result views.
+// Returns scrollKeyPopToRoot when enter is pressed, scrollKeyHandled for
+// j/k navigation, or scrollKeyUnhandled for anything else.
+func HandleScrollKeys(msg tea.KeyPressMsg, scroll *listScroll, totalLines, pageHeight int) scrollKeyResult {
+	switch msg.String() {
+	case "j", "down":
+		scroll.ScrollDown(totalLines, pageHeight)
+		return scrollKeyHandled
+	case "k", "up":
+		scroll.ScrollUp()
+		return scrollKeyHandled
+	case "enter":
+		return scrollKeyPopToRoot
+	}
+	return scrollKeyUnhandled
+}
+
+// filterInput manages text filter state and key handling shared across
+// screens that support '/' filtering (browse, status).
+type filterInput struct {
+	text   string
+	active bool
+}
+
+// HandleKey processes a key press while filtering is active. Returns true
+// when the filter text changed (callers should rebuild their filtered view).
+func (f *filterInput) HandleKey(msg tea.KeyPressMsg) (changed bool) {
+	switch msg.String() {
+	case "esc":
+		f.text = ""
+		f.active = false
+		return true
+	case "enter":
+		f.active = false
+		return false
+	case "backspace":
+		if len(f.text) > 0 {
+			f.text = f.text[:len(f.text)-1]
+			return true
+		}
+		return false
+	default:
+		if msg.Text != "" {
+			f.text += msg.Text
+			return true
+		}
+		return false
+	}
+}
+
+// Render returns the filter bar string. Returns empty when filter is inactive
+// and has no text.
+func (f *filterInput) Render(styles Styles) string {
+	if !f.active && f.text == "" {
+		return ""
+	}
+	if f.active {
+		return fmt.Sprintf("  %s %s█\n", styles.Subtle.Render("/"), f.text)
+	}
+	return fmt.Sprintf("  %s %s\n", styles.Subtle.Render("/"), f.text)
+}
+
+// MatchesAny returns true if any of the given strings contain the filter text
+// (case-insensitive). Returns true when filter is empty.
+func (f *filterInput) MatchesAny(fields ...string) bool {
+	if f.text == "" {
+		return true
+	}
+	lower := strings.ToLower(f.text)
+	for _, s := range fields {
+		if strings.Contains(strings.ToLower(s), lower) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tui/listview_test.go
+++ b/internal/tui/listview_test.go
@@ -34,9 +34,13 @@ func TestRenderScrolledLines_Windowed(t *testing.T) {
 	lines := []string{"a", "b", "c", "d", "e"}
 
 	got := RenderScrolledLines(styles, &scroll, lines, 2)
-	// With offset 1 and pageSize 2: should show "b" and "c" with indicators
+	// With offset 1 and pageSize 2, scroll indicators consume both rows,
+	// so only one content line ("b") is rendered alongside the indicators.
 	if !strings.Contains(got, "b") {
 		t.Errorf("expected to contain 'b', got %q", got)
+	}
+	if strings.Contains(got, "c") {
+		t.Errorf("expected 'c' to be hidden (indicators consume page budget), got %q", got)
 	}
 	if !strings.Contains(got, "more") {
 		t.Errorf("expected scroll indicators, got %q", got)

--- a/internal/tui/listview_test.go
+++ b/internal/tui/listview_test.go
@@ -1,0 +1,212 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestRenderScrolledLines_AllVisible(t *testing.T) {
+	styles := testStyles()
+	scroll := listScroll{}
+	lines := []string{"line1", "line2", "line3"}
+
+	got := RenderScrolledLines(styles, &scroll, lines, 10)
+	if got != "line1\nline2\nline3" {
+		t.Errorf("expected all lines joined, got %q", got)
+	}
+}
+
+func TestRenderScrolledLines_Empty(t *testing.T) {
+	styles := testStyles()
+	scroll := listScroll{}
+
+	got := RenderScrolledLines(styles, &scroll, nil, 10)
+	if got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestRenderScrolledLines_Windowed(t *testing.T) {
+	styles := testStyles()
+	scroll := listScroll{offset: 1}
+	lines := []string{"a", "b", "c", "d", "e"}
+
+	got := RenderScrolledLines(styles, &scroll, lines, 2)
+	// With offset 1 and pageSize 2: should show "b" and "c" with indicators
+	if !strings.Contains(got, "b") {
+		t.Errorf("expected to contain 'b', got %q", got)
+	}
+	if !strings.Contains(got, "more") {
+		t.Errorf("expected scroll indicators, got %q", got)
+	}
+}
+
+func TestContentHeight_ZeroReturnsUnlimited(t *testing.T) {
+	got := ContentHeight(0, 4)
+	if got != listScrollUnlimited {
+		t.Errorf("expected listScrollUnlimited, got %d", got)
+	}
+}
+
+func TestContentHeight_SubtractsChrome(t *testing.T) {
+	got := ContentHeight(30, 4)
+	if got != 26 {
+		t.Errorf("expected 26, got %d", got)
+	}
+}
+
+func TestContentHeight_MinThree(t *testing.T) {
+	got := ContentHeight(5, 4)
+	if got != 3 {
+		t.Errorf("expected 3, got %d", got)
+	}
+}
+
+func TestHandleScrollKeys_Down(t *testing.T) {
+	scroll := listScroll{}
+	msg := tea.KeyPressMsg{Code: 'j'}
+
+	result := HandleScrollKeys(msg, &scroll, 10, 5)
+	if result != scrollKeyHandled {
+		t.Errorf("expected scrollKeyHandled, got %d", result)
+	}
+	if scroll.offset != 1 {
+		t.Errorf("expected offset 1, got %d", scroll.offset)
+	}
+}
+
+func TestHandleScrollKeys_Up(t *testing.T) {
+	scroll := listScroll{offset: 3}
+	msg := tea.KeyPressMsg{Code: 'k'}
+
+	result := HandleScrollKeys(msg, &scroll, 10, 5)
+	if result != scrollKeyHandled {
+		t.Errorf("expected scrollKeyHandled, got %d", result)
+	}
+	if scroll.offset != 2 {
+		t.Errorf("expected offset 2, got %d", scroll.offset)
+	}
+}
+
+func TestHandleScrollKeys_Enter(t *testing.T) {
+	scroll := listScroll{}
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+
+	result := HandleScrollKeys(msg, &scroll, 10, 5)
+	if result != scrollKeyPopToRoot {
+		t.Errorf("expected scrollKeyPopToRoot, got %d", result)
+	}
+}
+
+func TestHandleScrollKeys_Unhandled(t *testing.T) {
+	scroll := listScroll{}
+	msg := tea.KeyPressMsg{Code: 'x'}
+
+	result := HandleScrollKeys(msg, &scroll, 10, 5)
+	if result != scrollKeyUnhandled {
+		t.Errorf("expected scrollKeyUnhandled, got %d", result)
+	}
+}
+
+func TestFilterInput_HandleKey_Append(t *testing.T) {
+	f := filterInput{active: true}
+	msg := tea.KeyPressMsg{Code: 'a', Text: "a"}
+	changed := f.HandleKey(msg)
+	if !changed || f.text != "a" {
+		t.Errorf("expected text='a' changed=true, got text=%q changed=%v", f.text, changed)
+	}
+}
+
+func TestFilterInput_HandleKey_Backspace(t *testing.T) {
+	f := filterInput{active: true, text: "abc"}
+	msg := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	changed := f.HandleKey(msg)
+	if !changed || f.text != "ab" {
+		t.Errorf("expected text='ab' changed=true, got text=%q changed=%v", f.text, changed)
+	}
+}
+
+func TestFilterInput_HandleKey_BackspaceEmpty(t *testing.T) {
+	f := filterInput{active: true, text: ""}
+	msg := tea.KeyPressMsg{Code: tea.KeyBackspace}
+	changed := f.HandleKey(msg)
+	if changed {
+		t.Error("expected changed=false for backspace on empty")
+	}
+}
+
+func TestFilterInput_HandleKey_Esc(t *testing.T) {
+	f := filterInput{active: true, text: "abc"}
+	msg := tea.KeyPressMsg{Code: tea.KeyEscape}
+	changed := f.HandleKey(msg)
+	if !changed || f.text != "" || f.active {
+		t.Errorf("expected text='' active=false changed=true, got text=%q active=%v changed=%v", f.text, f.active, changed)
+	}
+}
+
+func TestFilterInput_HandleKey_Enter(t *testing.T) {
+	f := filterInput{active: true, text: "abc"}
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	changed := f.HandleKey(msg)
+	if changed || f.active {
+		t.Errorf("expected active=false changed=false, got active=%v changed=%v", f.active, changed)
+	}
+	if f.text != "abc" {
+		t.Errorf("expected text preserved, got %q", f.text)
+	}
+}
+
+func TestFilterInput_MatchesAny(t *testing.T) {
+	f := filterInput{text: "foo"}
+	if !f.MatchesAny("foobar", "baz") {
+		t.Error("expected match on 'foobar'")
+	}
+	if f.MatchesAny("bar", "baz") {
+		t.Error("expected no match")
+	}
+}
+
+func TestFilterInput_MatchesAny_CaseInsensitive(t *testing.T) {
+	f := filterInput{text: "FOO"}
+	if !f.MatchesAny("foobar") {
+		t.Error("expected case-insensitive match")
+	}
+}
+
+func TestFilterInput_MatchesAny_EmptyFilter(t *testing.T) {
+	f := filterInput{text: ""}
+	if !f.MatchesAny("anything") {
+		t.Error("expected match when filter is empty")
+	}
+}
+
+func TestFilterInput_Render_Inactive(t *testing.T) {
+	styles := testStyles()
+	f := filterInput{}
+	if got := f.Render(styles); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestFilterInput_Render_Active(t *testing.T) {
+	styles := testStyles()
+	f := filterInput{active: true, text: "abc"}
+	got := f.Render(styles)
+	if !strings.Contains(got, "abc") || !strings.Contains(got, "█") {
+		t.Errorf("expected active cursor, got %q", got)
+	}
+}
+
+func TestFilterInput_Render_InactiveWithText(t *testing.T) {
+	styles := testStyles()
+	f := filterInput{active: false, text: "abc"}
+	got := f.Render(styles)
+	if !strings.Contains(got, "abc") {
+		t.Errorf("expected text shown, got %q", got)
+	}
+	if strings.Contains(got, "█") {
+		t.Errorf("expected no cursor when inactive, got %q", got)
+	}
+}

--- a/internal/tui/profile.go
+++ b/internal/tui/profile.go
@@ -379,14 +379,7 @@ func (s *profileScreen) updateDone(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (s *profileScreen) contentHeight() int {
-	if s.height == 0 {
-		return listScrollUnlimited
-	}
-	h := s.height - 4
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return ContentHeight(s.height, 4)
 }
 
 func (s *profileScreen) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/tui/profile.go
+++ b/internal/tui/profile.go
@@ -420,31 +420,7 @@ func (s *profileScreen) viewList() tea.View {
 	if len(s.listLines) == 0 {
 		s.listLines = splitLines(s.buildListContent())
 	}
-
-	lines := s.listLines
-	pageSize := s.contentHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.
-	if s.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if s.scroll.MoreBelow(len(lines), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := s.scroll.Window(len(lines), pageSize)
-
-	var b strings.Builder
-	if above := s.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(s.styles, "↑", above))
-	}
-	b.WriteString(strings.Join(lines[start:end], "\n"))
-	if below := s.scroll.MoreBelow(len(lines), pageSize); below > 0 {
-		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(s.styles, "↓", below))
-	}
-	return tea.NewView(b.String())
+	return tea.NewView(RenderScrolledLines(s.styles, &s.scroll, s.listLines, s.contentHeight()))
 }
 
 func (s *profileScreen) formatSwitchResult(target string, result *profile.SwitchResult) string {

--- a/internal/tui/remove.go
+++ b/internal/tui/remove.go
@@ -368,14 +368,10 @@ func (m *removeScreen) updateResult(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resultLines = splitLines(m.buildResultContent())
 	}
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
-		switch keyMsg.String() {
-		case "j", "down":
-			m.scroll.ScrollDown(len(m.resultLines), m.contentHeight())
+		switch HandleScrollKeys(keyMsg, &m.scroll, len(m.resultLines), m.contentHeight()) {
+		case scrollKeyHandled:
 			return m, nil
-		case "k", "up":
-			m.scroll.ScrollUp()
-			return m, nil
-		case "enter":
+		case scrollKeyPopToRoot:
 			return m, tea.Batch(
 				func() tea.Msg { return PopToRootMsg{} },
 				func() tea.Msg { return RefreshHeaderMsg{} },
@@ -386,14 +382,7 @@ func (m *removeScreen) updateResult(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *removeScreen) contentHeight() int {
-	if m.height == 0 {
-		return listScrollUnlimited
-	}
-	h := m.height - 4
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return ContentHeight(m.height, 4)
 }
 
 // --- Views ---
@@ -464,31 +453,7 @@ func (m *removeScreen) viewResult() tea.View {
 	if len(m.resultLines) == 0 {
 		m.resultLines = splitLines(m.buildResultContent())
 	}
-
-	lines := m.resultLines
-	pageSize := m.contentHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.
-	if m.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if m.scroll.MoreBelow(len(lines), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := m.scroll.Window(len(lines), pageSize)
-
-	var b strings.Builder
-	if above := m.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(m.styles, "↑", above))
-	}
-	b.WriteString(strings.Join(lines[start:end], "\n"))
-	if below := m.scroll.MoreBelow(len(lines), pageSize); below > 0 {
-		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(m.styles, "↓", below))
-	}
-	return tea.NewView(b.String())
+	return tea.NewView(RenderScrolledLines(m.styles, &m.scroll, m.resultLines, m.contentHeight()))
 }
 
 // --- Helpers ---

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -412,14 +412,7 @@ func (s *snapshotScreen) updateDone(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (s *snapshotScreen) contentHeight() int {
-	if s.height == 0 {
-		return listScrollUnlimited
-	}
-	h := s.height - 4
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return ContentHeight(s.height, 4)
 }
 
 func (s *snapshotScreen) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/internal/tui/snapshot.go
+++ b/internal/tui/snapshot.go
@@ -450,29 +450,5 @@ func (s *snapshotScreen) viewList() tea.View {
 	if len(s.listLines) == 0 {
 		s.listLines = splitLines(s.buildListContent())
 	}
-
-	lines := s.listLines
-	pageSize := s.contentHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.
-	if s.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if s.scroll.MoreBelow(len(lines), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := s.scroll.Window(len(lines), pageSize)
-
-	var b strings.Builder
-	if above := s.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(s.styles, "↑", above))
-	}
-	b.WriteString(strings.Join(lines[start:end], "\n"))
-	if below := s.scroll.MoreBelow(len(lines), pageSize); below > 0 {
-		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(s.styles, "↓", below))
-	}
-	return tea.NewView(b.String())
+	return tea.NewView(RenderScrolledLines(s.styles, &s.scroll, s.listLines, s.contentHeight()))
 }

--- a/internal/tui/source.go
+++ b/internal/tui/source.go
@@ -501,32 +501,7 @@ func (s *sourceScreen) viewList() tea.View {
 	if len(s.listLines) == 0 {
 		s.listLines = splitLines(s.buildListContent())
 	}
-
-	lines := s.listLines
-	pageSize := s.contentHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.
-	if s.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if s.scroll.MoreBelow(len(lines), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := s.scroll.Window(len(lines), pageSize)
-
-	var b strings.Builder
-	if above := s.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(s.styles, "↑", above))
-	}
-	b.WriteString(strings.Join(lines[start:end], "\n"))
-	if below := s.scroll.MoreBelow(len(lines), pageSize); below > 0 {
-		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(s.styles, "↓", below))
-	}
-
-	return tea.NewView(b.String())
+	return tea.NewView(RenderScrolledLines(s.styles, &s.scroll, s.listLines, s.contentHeight()))
 }
 
 func (s *sourceScreen) formatSyncResult(msg sourceSyncedMsg) string {

--- a/internal/tui/source.go
+++ b/internal/tui/source.go
@@ -456,17 +456,8 @@ func (s *sourceScreen) updateDone(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return s, nil
 }
 
-// contentHeight returns the visible row budget for the list view.
-// Returns listScrollUnlimited when height is unknown, disabling windowing.
 func (s *sourceScreen) contentHeight() int {
-	if s.height == 0 {
-		return listScrollUnlimited
-	}
-	h := s.height - 4 // root chrome: header + 2 blank separators + helpbar
-	if h < 3 {
-		h = 3
-	}
-	return h
+	return ContentHeight(s.height, 4)
 }
 
 // updateList handles key input while the source list is visible.

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -24,8 +24,7 @@ type statusScreen struct {
 	err     error
 	loaded  bool
 
-	filter    string
-	filtering bool
+	filter filterInput
 
 	// generation is incremented on every ScopeSwitchedMsg so that stale
 	// statusLoadedMsg results from a previous scope's goroutine are discarded.
@@ -48,11 +47,11 @@ func newStatusScreen(svc Services, styles Styles, isDark bool) *statusScreen {
 }
 
 func (s *statusScreen) Title() string     { return "Status" }
-func (s *statusScreen) InputActive() bool { return s.filtering }
+func (s *statusScreen) InputActive() bool { return s.filter.active }
 
 // HelpItems returns context-sensitive help items for the status screen.
 func (s *statusScreen) HelpItems() []HelpItem {
-	if s.filtering {
+	if s.filter.active {
 		return []HelpItem{
 			{"esc", "clear filter"},
 		}
@@ -96,6 +95,7 @@ func (s *statusScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.entries = nil
 		s.renderedLines = nil
 		s.scroll = listScroll{}
+		s.filter = filterInput{}
 		return s, s.Init()
 
 	case statusLoadedMsg:
@@ -120,8 +120,11 @@ func (s *statusScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// M11: Handle shortcut keys shown in help bar
 	case tea.KeyPressMsg:
-		if s.filtering {
-			return s.handleFilterKey(msg)
+		if s.filter.active {
+			if s.filter.HandleKey(msg) {
+				s.rebuildRendered()
+			}
+			return s, nil
 		}
 		switch msg.String() {
 		case "j", "down":
@@ -129,7 +132,7 @@ func (s *statusScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "k", "up":
 			s.scroll.ScrollUp()
 		case "/":
-			s.filtering = true
+			s.filter.active = true
 			return s, nil
 		case "d":
 			screen := newDeployScreen(s.svc, s.styles, s.isDark)
@@ -145,58 +148,18 @@ func (s *statusScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return s, nil
 }
 
-// contentHeight returns the number of content rows that fit in the terminal.
-// Returns listScrollUnlimited when height is unknown, disabling windowing.
 func (s *statusScreen) contentHeight() int {
-	if s.height == 0 {
-		return listScrollUnlimited
-	}
-	h := s.height - 4 // root chrome: header + 2 blank separators + helpbar
-	if h < 3 {
-		h = 3
-	}
-	return h
-}
-
-// handleFilterKey processes keystrokes while in filter mode.
-func (s *statusScreen) handleFilterKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	key := msg.String()
-	switch key {
-	case "esc":
-		s.filtering = false
-		s.filter = ""
-		s.rebuildRendered()
-		return s, nil
-	case "backspace":
-		if len(s.filter) > 0 {
-			s.filter = s.filter[:len(s.filter)-1]
-			s.rebuildRendered()
-		}
-		return s, nil
-	case "enter":
-		s.filtering = false
-		return s, nil
-	default:
-		// Append printable characters to filter (msg.Text is empty for control keys).
-		if msg.Text != "" {
-			s.filter += msg.Text
-			s.rebuildRendered()
-		}
-		return s, nil
-	}
+	return ContentHeight(s.height, 4) // root chrome: header + 2 blank separators + helpbar
 }
 
 // filteredEntries returns entries matching the current filter.
 func (s *statusScreen) filteredEntries() []deploy.StatusEntry {
-	if s.filter == "" {
+	if s.filter.text == "" {
 		return s.entries
 	}
-	lower := strings.ToLower(s.filter)
 	var result []deploy.StatusEntry
 	for _, e := range s.entries {
-		name := strings.ToLower(e.Deployment.AssetName)
-		src := strings.ToLower(e.Deployment.SourceID)
-		if strings.Contains(name, lower) || strings.Contains(src, lower) {
+		if s.filter.MatchesAny(e.Deployment.AssetName, e.Deployment.SourceID) {
 			result = append(result, e)
 		}
 	}
@@ -236,8 +199,8 @@ func (s *statusScreen) buildContent() string {
 				styled, e.Deployment.AssetName, s.styles.Subtle.Render(scope), s.styles.Subtle.Render(e.Deployment.SourceID))
 		}
 	}
-	if s.filter != "" {
-		fmt.Fprintf(&b, "\n  %d/%d matching %q", len(filtered), len(s.entries), s.filter)
+	if s.filter.text != "" {
+		fmt.Fprintf(&b, "\n  %d/%d matching %q", len(filtered), len(s.entries), s.filter.text)
 	} else {
 		fmt.Fprintf(&b, "\n  %d deployed", len(s.entries))
 	}
@@ -260,40 +223,9 @@ func (s *statusScreen) View() tea.View {
 		return tea.NewView("  " + NothingDeployed())
 	}
 
-	var filterLine string
-	if s.filtering {
-		filterLine = fmt.Sprintf("  filter: %s█\n", s.filter)
-	} else if s.filter != "" {
-		filterLine = fmt.Sprintf("  filter: %s\n", s.filter)
-	}
-
-	lines := s.renderedLines
-	pageSize := s.contentHeight()
-	// Reserve rows for scroll indicators so they don't push content past the
-	// terminal height budget.  MoreAbove depends only on the offset (known
-	// before windowing); MoreBelow is checked after we've already reduced the
-	// budget, so the indicator row itself is accounted for.
-	if s.scroll.MoreAbove() > 0 {
-		pageSize--
-	}
-	if s.scroll.MoreBelow(len(lines), pageSize) > 0 {
-		pageSize--
-	}
-	if pageSize < 1 {
-		pageSize = 1
-	}
-	start, end := s.scroll.Window(len(lines), pageSize)
-
-	var b strings.Builder
-	if above := s.scroll.MoreAbove(); above > 0 {
-		fmt.Fprintf(&b, "%s\n", scrollIndicatorLine(s.styles, "↑", above))
-	}
-	b.WriteString(strings.Join(lines[start:end], "\n"))
-	if below := s.scroll.MoreBelow(len(lines), pageSize); below > 0 {
-		fmt.Fprintf(&b, "\n%s", scrollIndicatorLine(s.styles, "↓", below))
-	}
-
-	return tea.NewView(filterLine + b.String())
+	filterLine := s.filter.Render(s.styles)
+	content := RenderScrolledLines(s.styles, &s.scroll, s.renderedLines, s.contentHeight())
+	return tea.NewView(filterLine + content)
 }
 
 // healthGlyph returns the text glyph for the given health status.

--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -444,7 +444,7 @@ func TestStatusScreen_SlashEntersFilterMode(t *testing.T) {
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: '/'}))
 
-	if !s.filtering {
+	if !s.filter.active {
 		t.Fatal("expected filtering=true after pressing /")
 	}
 	if !s.InputActive() {
@@ -459,7 +459,7 @@ func TestStatusScreen_FilterMatchesAssetName(t *testing.T) {
 	s.entries = testStatusEntries()
 	s.renderedLines = splitLines(s.buildContent())
 
-	s.filter = "greeting"
+	s.filter.text = "greeting"
 	filtered := s.filteredEntries()
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 match for 'greeting', got %d", len(filtered))
@@ -475,7 +475,7 @@ func TestStatusScreen_FilterMatchesSourceID(t *testing.T) {
 	s.loaded = true
 	s.entries = testStatusEntries()
 
-	s.filter = "dotfiles"
+	s.filter.text = "dotfiles"
 	filtered := s.filteredEntries()
 	// All test entries have source "dotfiles"
 	if len(filtered) != len(s.entries) {
@@ -489,7 +489,7 @@ func TestStatusScreen_FilterIsCaseInsensitive(t *testing.T) {
 	s.loaded = true
 	s.entries = testStatusEntries()
 
-	s.filter = "GREETING"
+	s.filter.text = "GREETING"
 	filtered := s.filteredEntries()
 	if len(filtered) != 1 {
 		t.Fatalf("expected 1 match for 'GREETING' (case-insensitive), got %d", len(filtered))
@@ -502,16 +502,16 @@ func TestStatusScreen_EscClearsFilter(t *testing.T) {
 	s.loaded = true
 	s.entries = testStatusEntries()
 	s.renderedLines = splitLines(s.buildContent())
-	s.filtering = true
-	s.filter = "test"
+	s.filter.active = true
+	s.filter.text = "test"
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
 
-	if s.filtering {
+	if s.filter.active {
 		t.Fatal("expected filtering=false after esc")
 	}
-	if s.filter != "" {
-		t.Fatalf("expected filter cleared, got %q", s.filter)
+	if s.filter.text != "" {
+		t.Fatalf("expected filter cleared, got %q", s.filter.text)
 	}
 }
 
@@ -521,12 +521,12 @@ func TestStatusScreen_ViewShowsFilterInputWhenFiltering(t *testing.T) {
 	s.loaded = true
 	s.entries = testStatusEntries()
 	s.renderedLines = splitLines(s.buildContent())
-	s.filtering = true
-	s.filter = "test"
+	s.filter.active = true
+	s.filter.text = "test"
 
 	v := s.View()
-	if !strings.Contains(v.Content, "filter: test") {
-		t.Error("expected view to show filter input")
+	if !strings.Contains(v.Content, "test") || !strings.Contains(v.Content, "█") {
+		t.Error("expected view to show filter input with cursor")
 	}
 }
 
@@ -552,16 +552,16 @@ func TestStatusScreen_EnterConfirmsFilter(t *testing.T) {
 	s.loaded = true
 	s.entries = testStatusEntries()
 	s.renderedLines = splitLines(s.buildContent())
-	s.filtering = true
-	s.filter = "greeting"
+	s.filter.active = true
+	s.filter.text = "greeting"
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
 
-	if s.filtering {
+	if s.filter.active {
 		t.Fatal("expected filtering=false after enter (confirm)")
 	}
-	if s.filter != "greeting" {
-		t.Fatalf("enter should preserve filter text, got %q", s.filter)
+	if s.filter.text != "greeting" {
+		t.Fatalf("enter should preserve filter text, got %q", s.filter.text)
 	}
 }
 
@@ -571,16 +571,16 @@ func TestStatusScreen_BackspaceOnEmptyFilterDoesNothing(t *testing.T) {
 	s.loaded = true
 	s.entries = testStatusEntries()
 	s.renderedLines = splitLines(s.buildContent())
-	s.filtering = true
-	s.filter = ""
+	s.filter.active = true
+	s.filter.text = ""
 
 	s.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyBackspace}))
 
-	if s.filter != "" {
-		t.Fatalf("backspace on empty filter should leave it empty, got %q", s.filter)
+	if s.filter.text != "" {
+		t.Fatalf("backspace on empty filter should leave it empty, got %q", s.filter.text)
 	}
 	// Should still be filtering (backspace doesn't exit filter mode).
-	if !s.filtering {
+	if !s.filter.active {
 		t.Fatal("backspace on empty should not exit filter mode")
 	}
 }
@@ -588,7 +588,7 @@ func TestStatusScreen_BackspaceOnEmptyFilterDoesNothing(t *testing.T) {
 func TestStatusScreen_HelpShowsEscWhenFiltering(t *testing.T) {
 	svc := newMockServices()
 	s := newStatusScreen(svc, NewStyles(true), true)
-	s.filtering = true
+	s.filter.active = true
 	items := s.HelpItems()
 	found := false
 	for _, item := range items {


### PR DESCRIPTION
## Summary

- Extracts shared list rendering components into `internal/tui/listview.go`, eliminating ~175 lines of duplicated code across 4 TUI screens
- Unifies filter bar rendering to consistent `/ text█` style across browse and status screens
- Adds comprehensive tests for all shared components in `listview_test.go`

## What changed

| Component | Replaces |
|-----------|----------|
| `RenderScrolledLines` | Identical scroll-window-indicator code in status, deploy, remove |
| `ContentHeight` | 4 copies of terminal-height-to-rows calculation |
| `filterInput` | Separate filter key handling + text matching in browse, status |
| `HandleScrollKeys` | Duplicate j/k/enter handling in deploy, remove result views |

## Test plan

- [x] All 21 packages pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Existing TUI tests updated for new `filterInput` struct fields
- [x] New `listview_test.go` covers all shared components

Closes #55