### PR TITLE
feat(cli): prompt to run nd init on first use

### DIFF
--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -31,42 +31,15 @@ func newInitCmd(app *App) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
-			configPath := app.ConfigPath
-			configDir := filepath.Dir(configPath)
 
 			// Check if config already exists
-			if _, err := os.Stat(configPath); err == nil {
-				return fmt.Errorf("config already exists at %s; edit with 'nd settings edit'", configPath)
+			if _, err := os.Stat(app.ConfigPath); err == nil {
+				return fmt.Errorf("config already exists at %s; edit with 'nd settings edit'", app.ConfigPath)
 			}
 
-			// Create directory structure
-			dirs := []string{
-				configDir,
-				filepath.Join(configDir, "profiles"),
-				filepath.Join(configDir, "snapshots"),
-				filepath.Join(configDir, "snapshots", "user"),
-				filepath.Join(configDir, "snapshots", "auto"),
-				filepath.Join(configDir, "state"),
-			}
-			for _, dir := range dirs {
-				if err := os.MkdirAll(dir, 0o755); err != nil {
-					return fmt.Errorf("create directory %s: %w", dir, err)
-				}
-			}
-
-			// Write default config
-			defaultCfg := `version: 1
-default_scope: global
-default_agent: claude-code
-symlink_strategy: absolute
-sources: []
-`
-			if err := os.WriteFile(configPath, []byte(defaultCfg), 0o644); err != nil {
-				return fmt.Errorf("write config: %w", err)
-			}
-
-			if !app.JSON && !app.Quiet {
-				printHuman(w, "Initialized nd at %s\n", configDir)
+			configDir, err := runInitSetup(cmd, app)
+			if err != nil {
+				return err
 			}
 
 			// Deploy built-in assets
@@ -74,7 +47,7 @@ sources: []
 
 			if app.JSON {
 				result := map[string]interface{}{
-					"config_path": configPath,
+					"config_path": app.ConfigPath,
 					"config_dir":  configDir,
 				}
 				if deployed > 0 {
@@ -86,6 +59,44 @@ sources: []
 			return deployErr
 		},
 	}
+}
+
+// runInitSetup creates the config directory structure and writes the default
+// config file. Returns the config directory path. This is shared between the
+// init command and the first-run prompt in persistentPreRun.
+func runInitSetup(cmd *cobra.Command, app *App) (string, error) {
+	configPath := app.ConfigPath
+	configDir := filepath.Dir(configPath)
+
+	dirs := []string{
+		configDir,
+		filepath.Join(configDir, "profiles"),
+		filepath.Join(configDir, "snapshots"),
+		filepath.Join(configDir, "snapshots", "user"),
+		filepath.Join(configDir, "snapshots", "auto"),
+		filepath.Join(configDir, "state"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", fmt.Errorf("create directory %s: %w", dir, err)
+		}
+	}
+
+	defaultCfg := `version: 1
+default_scope: global
+default_agent: claude-code
+symlink_strategy: absolute
+sources: []
+`
+	if err := os.WriteFile(configPath, []byte(defaultCfg), 0o644); err != nil {
+		return "", fmt.Errorf("write config: %w", err)
+	}
+
+	if !app.JSON && !app.Quiet {
+		printHuman(cmd.OutOrStdout(), "Initialized nd at %s\n", configDir)
+	}
+
+	return configDir, nil
 }
 
 // deployBuiltinAssets extracts and deploys all built-in assets during init.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -183,12 +183,20 @@ func persistentPreRun(cmd *cobra.Command, app *App) error {
 }
 
 // needsInit returns true if the command requires an initialized config.
-// Commands that work without config are exempt.
+// Commands that work without config are exempt. Walks the command ancestry
+// so subcommands (e.g. "completion bash") and Cobra internals are also exempt.
 func needsInit(cmd *cobra.Command) bool {
-	for current := cmd; current != nil; current = current.Parent() {
-		switch current.Name() {
-		case "nd", "init", "version", "completion", "help", "__complete", "__completeNoDesc":
+	for c := cmd; c != nil; c = c.Parent() {
+		switch c.Name() {
+		case "init", "version", "completion", "help",
+			"__complete", "__completeNoDesc":
 			return false
+		case "nd":
+			// The root "nd" command itself doesn't need init,
+			// but subcommands under it do.
+			if c == cmd {
+				return false
+			}
 		}
 	}
 	return true
@@ -196,8 +204,14 @@ func needsInit(cmd *cobra.Command) bool {
 
 // offerInit warns the user that nd is not initialized and offers to run init.
 // In interactive mode, prompts for confirmation. In non-interactive mode or
-// if declined, prints a hint and continues.
+// if declined, prints a hint and continues. Skipped during --dry-run.
 func offerInit(cmd *cobra.Command, app *App) error {
+	if app.DryRun {
+		printHuman(cmd.ErrOrStderr(), "nd is not initialized (dry-run: skipping auto-init).\n")
+		printHuman(cmd.ErrOrStderr(), "Run 'nd init' to get started.\n")
+		return nil
+	}
+
 	w := cmd.ErrOrStderr()
 	printHuman(w, "nd is not initialized.\n")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,11 +147,15 @@ func persistentPreRun(cmd *cobra.Command, app *App) error {
 	app.BackupDir = filepath.Join(filepath.Dir(app.ConfigPath), "backups")
 
 	// Offer init when config doesn't exist and command needs it
-	if _, err := os.Stat(app.ConfigPath); os.IsNotExist(err) {
-		if needsInit(cmd) {
-			if err := offerInit(cmd, app); err != nil {
-				return err
+	if _, err := os.Stat(app.ConfigPath); err != nil {
+		if os.IsNotExist(err) {
+			if needsInit(cmd) {
+				if err := offerInit(cmd, app); err != nil {
+					return err
+				}
 			}
+		} else {
+			return fmt.Errorf("stat config path %q: %w", app.ConfigPath, err)
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,9 +181,11 @@ func persistentPreRun(cmd *cobra.Command, app *App) error {
 // needsInit returns true if the command requires an initialized config.
 // Commands that work without config are exempt.
 func needsInit(cmd *cobra.Command) bool {
-	switch cmd.Name() {
-	case "nd", "init", "version", "completion", "help":
-		return false
+	for current := cmd; current != nil; current = current.Parent() {
+		switch current.Name() {
+		case "nd", "init", "version", "completion", "help", "__complete", "__completeNoDesc":
+			return false
+		}
 	}
 	return true
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,6 +146,15 @@ func persistentPreRun(cmd *cobra.Command, app *App) error {
 	// Derive backup dir from config dir
 	app.BackupDir = filepath.Join(filepath.Dir(app.ConfigPath), "backups")
 
+	// Offer init when config doesn't exist and command needs it
+	if _, err := os.Stat(app.ConfigPath); os.IsNotExist(err) {
+		if needsInit(cmd) {
+			if err := offerInit(cmd, app); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Validate scope
 	switch app.Scope {
 	case nd.ScopeGlobal, nd.ScopeProject:
@@ -166,6 +175,48 @@ func persistentPreRun(cmd *cobra.Command, app *App) error {
 		app.NoColor = true
 	}
 
+	return nil
+}
+
+// needsInit returns true if the command requires an initialized config.
+// Commands that work without config are exempt.
+func needsInit(cmd *cobra.Command) bool {
+	switch cmd.Name() {
+	case "nd", "init", "version", "completion", "help":
+		return false
+	}
+	return true
+}
+
+// offerInit warns the user that nd is not initialized and offers to run init.
+// In interactive mode, prompts for confirmation. In non-interactive mode or
+// if declined, prints a hint and continues.
+func offerInit(cmd *cobra.Command, app *App) error {
+	w := cmd.ErrOrStderr()
+	printHuman(w, "nd is not initialized.\n")
+
+	shouldInit := app.Yes
+	if !shouldInit && isTerminal() {
+		confirmed, err := confirm(cmd.InOrStdin(), w, "Run nd init now?", false)
+		if err == nil && confirmed {
+			shouldInit = true
+		}
+	}
+
+	if shouldInit {
+		configDir, err := runInitSetup(cmd, app)
+		if err != nil {
+			return err
+		}
+		_, err = deployBuiltinAssets(cmd, app, configDir, app.initAgent)
+		if err != nil {
+			return err
+		}
+		printHuman(w, "\n")
+		return nil
+	}
+
+	printHuman(w, "Run 'nd init' to get started.\n")
 	return nil
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -149,11 +149,23 @@ func TestFirstRunPrompt_NonInteractive_ShowsHint(t *testing.T) {
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
-	// Pipe stdin so isTerminal() returns false
-	rootCmd.SetIn(strings.NewReader(""))
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = oldStdin
+	}()
+
 	rootCmd.SetArgs([]string{"--config", configPath, "list"})
 
-	// Command will likely fail after the hint (no config), but the hint should appear
+	// Command will likely fail after the hint (no config), but the hint should appear.
 	_ = rootCmd.Execute()
 
 	got := out.String()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestRootCmd_Help(t *testing.T) {
@@ -92,6 +96,98 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 	got := out.String()
 	if !strings.Contains(got, "nd version") {
 		t.Errorf("expected version info in output, got: %s", got)
+	}
+}
+
+func TestNeedsInit_ExemptCommands(t *testing.T) {
+	exempt := []string{"nd", "init", "version", "completion", "help"}
+	for _, name := range exempt {
+		cmd := &cobra.Command{Use: name}
+		if needsInit(cmd) {
+			t.Errorf("needsInit(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestNeedsInit_NonExemptCommands(t *testing.T) {
+	nonExempt := []string{"deploy", "list", "status", "doctor", "remove", "source"}
+	for _, name := range nonExempt {
+		cmd := &cobra.Command{Use: name}
+		if !needsInit(cmd) {
+			t.Errorf("needsInit(%q) = false, want true", name)
+		}
+	}
+}
+
+func TestFirstRunPrompt_VersionSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "nonexistent", "config.yaml")
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--config", configPath, "version"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out.String(), "not initialized") {
+		t.Error("version command should not trigger init prompt")
+	}
+}
+
+func TestFirstRunPrompt_NonInteractive_ShowsHint(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "nonexistent", "config.yaml")
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	// Pipe stdin so isTerminal() returns false
+	rootCmd.SetIn(strings.NewReader(""))
+	rootCmd.SetArgs([]string{"--config", configPath, "list"})
+
+	// Command will likely fail after the hint (no config), but the hint should appear
+	_ = rootCmd.Execute()
+
+	got := out.String()
+	if !strings.Contains(got, "not initialized") {
+		t.Errorf("expected 'not initialized' warning, got: %s", got)
+	}
+	if !strings.Contains(got, "nd init") {
+		t.Errorf("expected 'nd init' hint, got: %s", got)
+	}
+}
+
+func TestFirstRunPrompt_YesFlag_RunsInit(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".config", "nd", "config.yaml")
+
+	app := &App{initAgent: testInitAgent(t, tmp)}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	// --yes auto-accepts the init prompt; list will then run (with empty sources)
+	rootCmd.SetArgs([]string{"--config", configPath, "--yes", "list"})
+
+	_ = rootCmd.Execute()
+
+	// Config should now exist
+	if _, err := os.Stat(configPath); err != nil {
+		t.Errorf("expected config file to be created: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Initialized") {
+		t.Errorf("expected 'Initialized' in output, got: %s", got)
 	}
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -100,12 +100,26 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 }
 
 func TestNeedsInit_ExemptCommands(t *testing.T) {
-	exempt := []string{"nd", "init", "version", "completion", "help"}
+	exempt := []string{"init", "version", "completion", "help", "__complete", "__completeNoDesc"}
 	for _, name := range exempt {
 		cmd := &cobra.Command{Use: name}
 		if needsInit(cmd) {
 			t.Errorf("needsInit(%q) = true, want false", name)
 		}
+	}
+
+	// Root command (no parent) is exempt
+	root := &cobra.Command{Use: "nd"}
+	if needsInit(root) {
+		t.Error("needsInit(root nd) = true, want false")
+	}
+
+	// Subcommands of exempt parents should also be exempt (e.g. "completion bash")
+	parent := &cobra.Command{Use: "completion"}
+	child := &cobra.Command{Use: "bash"}
+	parent.AddCommand(child)
+	if needsInit(child) {
+		t.Error("needsInit(completion > bash) = true, want false")
 	}
 }
 
@@ -143,13 +157,7 @@ func TestFirstRunPrompt_NonInteractive_ShowsHint(t *testing.T) {
 	tmp := t.TempDir()
 	configPath := filepath.Join(tmp, "nonexistent", "config.yaml")
 
-	app := &App{}
-	rootCmd := NewRootCmd(app)
-
-	var out bytes.Buffer
-	rootCmd.SetOut(&out)
-	rootCmd.SetErr(&out)
-
+	// Replace os.Stdin with a pipe so isTerminal() returns false deterministically
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("create pipe: %v", err)
@@ -159,10 +167,14 @@ func TestFirstRunPrompt_NonInteractive_ShowsHint(t *testing.T) {
 
 	oldStdin := os.Stdin
 	os.Stdin = r
-	defer func() {
-		os.Stdin = oldStdin
-	}()
+	defer func() { os.Stdin = oldStdin }()
 
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
 	rootCmd.SetArgs([]string{"--config", configPath, "list"})
 
 	// Command will likely fail after the hint (no config), but the hint should appear.
@@ -174,6 +186,30 @@ func TestFirstRunPrompt_NonInteractive_ShowsHint(t *testing.T) {
 	}
 	if !strings.Contains(got, "nd init") {
 		t.Errorf("expected 'nd init' hint, got: %s", got)
+	}
+}
+
+func TestFirstRunPrompt_DryRun_SkipsInit(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "nonexistent", "config.yaml")
+
+	app := &App{}
+	rootCmd := NewRootCmd(app)
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--config", configPath, "--dry-run", "--yes", "list"})
+
+	_ = rootCmd.Execute()
+
+	got := out.String()
+	if !strings.Contains(got, "dry-run: skipping auto-init") {
+		t.Errorf("expected dry-run skip message, got: %s", got)
+	}
+	// Config should NOT have been created
+	if _, err := os.Stat(configPath); err == nil {
+		t.Error("config file should not exist after dry-run")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #73. New users running CLI commands before `nd init` now get a warning and an offer to bootstrap inline, closing the post-install onboarding gap.

- Detects missing config in `persistentPreRun` for commands that need it
- Interactive terminals: prompts `Run nd init now? [y/N]`; accepting runs full init + built-in deploy before the original command
- Non-interactive or declined: prints `Run 'nd init' to get started.` and continues
- `--yes` flag auto-accepts (CI-friendly)
- Exempt commands (init, version, completion, help, root/TUI) are unaffected

## Changes

- `cmd/init_cmd.go`: extracted `runInitSetup()` as a shared function for directory creation + config writing
- `cmd/root.go`: added `needsInit()`, `offerInit()`, and wired detection into `persistentPreRun`
- `cmd/root_test.go`: 5 new tests covering exempt/non-exempt classification, version bypass, non-interactive hint, and `--yes` auto-init

## Test plan

- [x] All 21 packages pass (`go test ./...`)
- [x] `go vet ./...` clean
- [ ] Manual: `nd list` with no config → shows warning + prompt
- [ ] Manual: `nd list --yes` with no config → auto-inits then lists
- [ ] Manual: `nd version` with no config → no prompt
- [ ] Manual: `nd init` after auto-init → errors with "config already exists"