### PR TITLE
feat(site): add enhanced code blocks with catppuccin themes and terminal frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ staleness-output.json
 site/public/
 site/resources/
 site/.hugo_build.lock
+site/_vendor/

--- a/site/assets/css/custom.css
+++ b/site/assets/css/custom.css
@@ -4,6 +4,11 @@
  * Sections:
  *   1. Chroma light theme (catppuccin-latte)
  *   2. Chroma dark theme (catppuccin-mocha, .dark prefix)
+ *   3. Hextra conflict cancellation
+ *   4. Terminal frame header (nd-code-header)
+ *   5. Copy button offset for terminal frame
+ *   6. Inline line number suppression
+ *   7. Per-line hover highlighting
  */
 
 /* ==========================================================================
@@ -167,3 +172,87 @@
 /* GenericSubheading */ .dark .chroma .gu { color:#fab387;font-weight:bold }
 /* GenericTraceback */ .dark .chroma .gt { color:#f38ba8 }
 /* GenericUnderline */ .dark .chroma .gl { text-decoration:underline }
+
+/* ==========================================================================
+   3. Hextra conflict cancellation
+   Hextra's highlight.css applies padding-top: 3rem to the second child div's
+   pre element (for its own filename header). When nd-code-header is present,
+   the code div becomes the second child, triggering excess padding. Cancel it.
+   ========================================================================== */
+
+.hextra-code-block .nd-code-header ~ div pre { padding-top: 1rem; }
+
+/* ==========================================================================
+   4. Terminal frame header (nd-code-header)
+   macOS-style bar with traffic-light dots and filename display.
+   ========================================================================== */
+
+.nd-code-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background-color: #dce0e8;
+  border-radius: 0.375rem 0.375rem 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  color: #6c6f85;
+  line-height: 1;
+}
+
+.dark .nd-code-header {
+  background-color: #181825;
+  color: #a6adc8;
+}
+
+.nd-code-header + div .chroma {
+  border-radius: 0 0 0.375rem 0.375rem;
+}
+
+.nd-dots {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.nd-dots span {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.nd-dots span:nth-child(1) { background-color: #ff5f57; }
+.nd-dots span:nth-child(2) { background-color: #febc2e; }
+.nd-dots span:nth-child(3) { background-color: #28c840; }
+
+.nd-filename {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ==========================================================================
+   5. Copy button offset for terminal frame
+   When nd-code-header is present, the copy button (always top-0 since we
+   pass filename="" to Hextra's partial) needs to shift down past the header.
+   ========================================================================== */
+
+.nd-code-header ~ .hextra-code-copy-btn-container {
+  top: 2.25rem;
+}
+
+/* ==========================================================================
+   6. Inline line number suppression
+   Paired with render hook's lineNos:inline default. Hides .ln spans globally;
+   users who set linenos=true get table-mode line numbers instead.
+   ========================================================================== */
+
+.chroma .ln { display: none; }
+
+/* ==========================================================================
+   7. Per-line hover highlighting
+   ========================================================================== */
+
+.chroma .line:hover { background-color: rgba(0, 0, 0, 0.04); }
+.dark .chroma .line:hover { background-color: rgba(255, 255, 255, 0.06); }

--- a/site/assets/css/custom.css
+++ b/site/assets/css/custom.css
@@ -1,0 +1,169 @@
+/*
+ * nd documentation custom styles
+ *
+ * Sections:
+ *   1. Chroma light theme (catppuccin-latte)
+ *   2. Chroma dark theme (catppuccin-mocha, .dark prefix)
+ */
+
+/* ==========================================================================
+   1. Chroma light theme — catppuccin-latte
+   Generated: hugo gen chromastyles --style=catppuccin-latte
+   ========================================================================== */
+
+/* Background */ .bg { color:#4c4f69;background-color:#eff1f5; }
+/* PreWrapper */ .chroma { color:#4c4f69;background-color:#eff1f5;-webkit-text-size-adjust:none; }
+/* Error */ .chroma .err { color:#d20f39 }
+/* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .chroma .hl { background-color:#bcc0cc }
+/* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#8c8fa1 }
+/* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#8c8fa1 }
+/* Line */ .chroma .line { display:flex; }
+/* Keyword */ .chroma .k { color:#8839ef }
+/* KeywordConstant */ .chroma .kc { color:#fe640b }
+/* KeywordDeclaration */ .chroma .kd { color:#d20f39 }
+/* KeywordNamespace */ .chroma .kn { color:#179299 }
+/* KeywordPseudo */ .chroma .kp { color:#8839ef }
+/* KeywordReserved */ .chroma .kr { color:#8839ef }
+/* KeywordType */ .chroma .kt { color:#d20f39 }
+/* NameAttribute */ .chroma .na { color:#1e66f5 }
+/* NameClass */ .chroma .nc { color:#df8e1d }
+/* NameConstant */ .chroma .no { color:#df8e1d }
+/* NameDecorator */ .chroma .nd { color:#1e66f5;font-weight:bold }
+/* NameEntity */ .chroma .ni { color:#179299 }
+/* NameException */ .chroma .ne { color:#fe640b }
+/* NameLabel */ .chroma .nl { color:#04a5e5 }
+/* NameNamespace */ .chroma .nn { color:#fe640b }
+/* NameProperty */ .chroma .py { color:#fe640b }
+/* NameTag */ .chroma .nt { color:#8839ef }
+/* NameBuiltin */ .chroma .nb { color:#04a5e5 }
+/* NameBuiltinPseudo */ .chroma .bp { color:#04a5e5 }
+/* NameVariable */ .chroma .nv { color:#dc8a78 }
+/* NameVariableClass */ .chroma .vc { color:#dc8a78 }
+/* NameVariableGlobal */ .chroma .vg { color:#dc8a78 }
+/* NameVariableInstance */ .chroma .vi { color:#dc8a78 }
+/* NameVariableMagic */ .chroma .vm { color:#dc8a78 }
+/* NameFunction */ .chroma .nf { color:#1e66f5 }
+/* NameFunctionMagic */ .chroma .fm { color:#1e66f5 }
+/* LiteralString */ .chroma .s { color:#40a02b }
+/* LiteralStringAffix */ .chroma .sa { color:#d20f39 }
+/* LiteralStringBacktick */ .chroma .sb { color:#40a02b }
+/* LiteralStringChar */ .chroma .sc { color:#40a02b }
+/* LiteralStringDelimiter */ .chroma .dl { color:#1e66f5 }
+/* LiteralStringDoc */ .chroma .sd { color:#9ca0b0 }
+/* LiteralStringDouble */ .chroma .s2 { color:#40a02b }
+/* LiteralStringEscape */ .chroma .se { color:#1e66f5 }
+/* LiteralStringHeredoc */ .chroma .sh { color:#9ca0b0 }
+/* LiteralStringInterpol */ .chroma .si { color:#40a02b }
+/* LiteralStringOther */ .chroma .sx { color:#40a02b }
+/* LiteralStringRegex */ .chroma .sr { color:#179299 }
+/* LiteralStringSingle */ .chroma .s1 { color:#40a02b }
+/* LiteralStringSymbol */ .chroma .ss { color:#40a02b }
+/* LiteralNumber */ .chroma .m { color:#fe640b }
+/* LiteralNumberBin */ .chroma .mb { color:#fe640b }
+/* LiteralNumberFloat */ .chroma .mf { color:#fe640b }
+/* LiteralNumberHex */ .chroma .mh { color:#fe640b }
+/* LiteralNumberInteger */ .chroma .mi { color:#fe640b }
+/* LiteralNumberIntegerLong */ .chroma .il { color:#fe640b }
+/* LiteralNumberOct */ .chroma .mo { color:#fe640b }
+/* Operator */ .chroma .o { color:#04a5e5;font-weight:bold }
+/* OperatorWord */ .chroma .ow { color:#04a5e5;font-weight:bold }
+/* Comment */ .chroma .c { color:#9ca0b0;font-style:italic }
+/* CommentHashbang */ .chroma .ch { color:#acb0be;font-style:italic }
+/* CommentMultiline */ .chroma .cm { color:#9ca0b0;font-style:italic }
+/* CommentSingle */ .chroma .c1 { color:#9ca0b0;font-style:italic }
+/* CommentSpecial */ .chroma .cs { color:#9ca0b0;font-style:italic }
+/* CommentPreproc */ .chroma .cp { color:#9ca0b0;font-style:italic }
+/* CommentPreprocFile */ .chroma .cpf { color:#9ca0b0;font-weight:bold;font-style:italic }
+/* GenericDeleted */ .chroma .gd { color:#d20f39;background-color:#ccd0da }
+/* GenericEmph */ .chroma .ge { font-style:italic }
+/* GenericError */ .chroma .gr { color:#d20f39 }
+/* GenericHeading */ .chroma .gh { color:#fe640b;font-weight:bold }
+/* GenericInserted */ .chroma .gi { color:#40a02b;background-color:#ccd0da }
+/* GenericStrong */ .chroma .gs { font-weight:bold }
+/* GenericSubheading */ .chroma .gu { color:#fe640b;font-weight:bold }
+/* GenericTraceback */ .chroma .gt { color:#d20f39 }
+/* GenericUnderline */ .chroma .gl { text-decoration:underline }
+
+/* ==========================================================================
+   2. Chroma dark theme — catppuccin-mocha (.dark prefix)
+   Generated: hugo gen chromastyles --style=catppuccin-mocha
+   ========================================================================== */
+
+/* Background */ .dark .bg { color:#cdd6f4;background-color:#1e1e2e; }
+/* PreWrapper */ .dark .chroma { color:#cdd6f4;background-color:#1e1e2e;-webkit-text-size-adjust:none; }
+/* Error */ .dark .chroma .err { color:#f38ba8 }
+/* LineLink */ .dark .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
+/* LineTableTD */ .dark .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
+/* LineTable */ .dark .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
+/* LineHighlight */ .dark .chroma .hl { background-color:#45475a }
+/* LineNumbersTable */ .dark .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f849c }
+/* LineNumbers */ .dark .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f849c }
+/* Line */ .dark .chroma .line { display:flex; }
+/* Keyword */ .dark .chroma .k { color:#cba6f7 }
+/* KeywordConstant */ .dark .chroma .kc { color:#fab387 }
+/* KeywordDeclaration */ .dark .chroma .kd { color:#f38ba8 }
+/* KeywordNamespace */ .dark .chroma .kn { color:#94e2d5 }
+/* KeywordPseudo */ .dark .chroma .kp { color:#cba6f7 }
+/* KeywordReserved */ .dark .chroma .kr { color:#cba6f7 }
+/* KeywordType */ .dark .chroma .kt { color:#f38ba8 }
+/* NameAttribute */ .dark .chroma .na { color:#89b4fa }
+/* NameClass */ .dark .chroma .nc { color:#f9e2af }
+/* NameConstant */ .dark .chroma .no { color:#f9e2af }
+/* NameDecorator */ .dark .chroma .nd { color:#89b4fa;font-weight:bold }
+/* NameEntity */ .dark .chroma .ni { color:#94e2d5 }
+/* NameException */ .dark .chroma .ne { color:#fab387 }
+/* NameLabel */ .dark .chroma .nl { color:#89dceb }
+/* NameNamespace */ .dark .chroma .nn { color:#fab387 }
+/* NameProperty */ .dark .chroma .py { color:#fab387 }
+/* NameTag */ .dark .chroma .nt { color:#cba6f7 }
+/* NameBuiltin */ .dark .chroma .nb { color:#89dceb }
+/* NameBuiltinPseudo */ .dark .chroma .bp { color:#89dceb }
+/* NameVariable */ .dark .chroma .nv { color:#f5e0dc }
+/* NameVariableClass */ .dark .chroma .vc { color:#f5e0dc }
+/* NameVariableGlobal */ .dark .chroma .vg { color:#f5e0dc }
+/* NameVariableInstance */ .dark .chroma .vi { color:#f5e0dc }
+/* NameVariableMagic */ .dark .chroma .vm { color:#f5e0dc }
+/* NameFunction */ .dark .chroma .nf { color:#89b4fa }
+/* NameFunctionMagic */ .dark .chroma .fm { color:#89b4fa }
+/* LiteralString */ .dark .chroma .s { color:#a6e3a1 }
+/* LiteralStringAffix */ .dark .chroma .sa { color:#f38ba8 }
+/* LiteralStringBacktick */ .dark .chroma .sb { color:#a6e3a1 }
+/* LiteralStringChar */ .dark .chroma .sc { color:#a6e3a1 }
+/* LiteralStringDelimiter */ .dark .chroma .dl { color:#89b4fa }
+/* LiteralStringDoc */ .dark .chroma .sd { color:#6c7086 }
+/* LiteralStringDouble */ .dark .chroma .s2 { color:#a6e3a1 }
+/* LiteralStringEscape */ .dark .chroma .se { color:#89b4fa }
+/* LiteralStringHeredoc */ .dark .chroma .sh { color:#6c7086 }
+/* LiteralStringInterpol */ .dark .chroma .si { color:#a6e3a1 }
+/* LiteralStringOther */ .dark .chroma .sx { color:#a6e3a1 }
+/* LiteralStringRegex */ .dark .chroma .sr { color:#94e2d5 }
+/* LiteralStringSingle */ .dark .chroma .s1 { color:#a6e3a1 }
+/* LiteralStringSymbol */ .dark .chroma .ss { color:#a6e3a1 }
+/* LiteralNumber */ .dark .chroma .m { color:#fab387 }
+/* LiteralNumberBin */ .dark .chroma .mb { color:#fab387 }
+/* LiteralNumberFloat */ .dark .chroma .mf { color:#fab387 }
+/* LiteralNumberHex */ .dark .chroma .mh { color:#fab387 }
+/* LiteralNumberInteger */ .dark .chroma .mi { color:#fab387 }
+/* LiteralNumberIntegerLong */ .dark .chroma .il { color:#fab387 }
+/* LiteralNumberOct */ .dark .chroma .mo { color:#fab387 }
+/* Operator */ .dark .chroma .o { color:#89dceb;font-weight:bold }
+/* OperatorWord */ .dark .chroma .ow { color:#89dceb;font-weight:bold }
+/* Comment */ .dark .chroma .c { color:#6c7086;font-style:italic }
+/* CommentHashbang */ .dark .chroma .ch { color:#585b70;font-style:italic }
+/* CommentMultiline */ .dark .chroma .cm { color:#6c7086;font-style:italic }
+/* CommentSingle */ .dark .chroma .c1 { color:#6c7086;font-style:italic }
+/* CommentSpecial */ .dark .chroma .cs { color:#6c7086;font-style:italic }
+/* CommentPreproc */ .dark .chroma .cp { color:#6c7086;font-style:italic }
+/* CommentPreprocFile */ .dark .chroma .cpf { color:#6c7086;font-weight:bold;font-style:italic }
+/* GenericDeleted */ .dark .chroma .gd { color:#f38ba8;background-color:#313244 }
+/* GenericEmph */ .dark .chroma .ge { font-style:italic }
+/* GenericError */ .dark .chroma .gr { color:#f38ba8 }
+/* GenericHeading */ .dark .chroma .gh { color:#fab387;font-weight:bold }
+/* GenericInserted */ .dark .chroma .gi { color:#a6e3a1;background-color:#313244 }
+/* GenericStrong */ .dark .chroma .gs { font-weight:bold }
+/* GenericSubheading */ .dark .chroma .gu { color:#fab387;font-weight:bold }
+/* GenericTraceback */ .dark .chroma .gt { color:#f38ba8 }
+/* GenericUnderline */ .dark .chroma .gl { text-decoration:underline }

--- a/site/layouts/_markup/render-codeblock.html
+++ b/site/layouts/_markup/render-codeblock.html
@@ -2,9 +2,10 @@
 {{- $base_url := .Attributes.base_url | default "" -}}
 {{- $lang := .Attributes.lang | default .Type -}}
 
-{{- /* Merge user options with lineNos:inline default. .Options (left) wins on conflicts,
-       so explicit linenos=false or linenos=true from the code fence overrides our default. */ -}}
-{{- $opts := merge .Options (dict "lineNos" "inline") -}}
+{{- /* Merge user options with lineNos:inline default. Hugo merge gives precedence to the
+       rightmost map, so .Options (right) wins on conflicts. User's explicit linenos=false
+       or linenos=true from the code fence overrides our default. */ -}}
+{{- $opts := merge (dict "lineNos" "inline") .Options -}}
 
 <div class="hextra-code-block hx:relative hx:mt-6 hx:first:mt-0 hx:group/code">
   {{- if $filename -}}

--- a/site/layouts/_markup/render-codeblock.html
+++ b/site/layouts/_markup/render-codeblock.html
@@ -1,0 +1,23 @@
+{{- $filename := .Attributes.filename | default "" -}}
+{{- $base_url := .Attributes.base_url | default "" -}}
+{{- $lang := .Attributes.lang | default .Type -}}
+
+{{- /* Merge user options with lineNos:inline default. .Options (left) wins on conflicts,
+       so explicit linenos=false or linenos=true from the code fence overrides our default. */ -}}
+{{- $opts := merge .Options (dict "lineNos" "inline") -}}
+
+<div class="hextra-code-block hx:relative hx:mt-6 hx:first:mt-0 hx:group/code">
+  {{- if $filename -}}
+    <div class="nd-code-header">
+      <span class="nd-dots"><span></span><span></span><span></span></span>
+      <span class="nd-filename">{{ $filename }}</span>
+    </div>
+  {{- end -}}
+
+  {{- /* Pass filename="" to suppress Hextra's built-in filename header */ -}}
+  {{- partial "components/codeblock" (dict "filename" "" "lang" $lang "base_url" $base_url "content" .Inner "options" $opts) -}}
+
+  {{- if or (eq site.Params.highlight.copy.enable nil) (site.Params.highlight.copy.enable) -}}
+    {{- partialCached "components/codeblock-copy-button" (dict "filename" "") "" -}}
+  {{- end -}}
+</div>

--- a/site/layouts/partials/custom/head-end.html
+++ b/site/layouts/partials/custom/head-end.html
@@ -1,2 +1,4 @@
 <meta name="llms-txt" content="{{ "llms.txt" | absURL }}">
 <meta name="agent-directive" content="For AI agents: see {{ "llms.txt" | absURL }} for a structured index of this documentation.">
+{{- $css := resources.Get "css/custom.css" | resources.Fingerprint -}}
+<link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}" crossorigin="anonymous">


### PR DESCRIPTION
## Summary

- Replace default Chroma syntax theme with catppuccin-mocha (dark) / catppuccin-latte (light) pair, loaded via Hugo Pipes custom CSS injection
- Add code block render hook that extends Hextra's hook with terminal frame header support (`filename` attribute), inline line numbers for per-line hover, and copy button preservation
- Style macOS-style terminal frame with traffic-light dots, per-line hover highlighting, Hextra padding conflict cancellation, and line number suppression

## What changed

| File | Purpose |
|------|---------|
| `site/assets/css/custom.css` | Catppuccin light/dark Chroma themes, terminal frame CSS, hover, line number suppression, Hextra conflict overrides |
| `site/layouts/partials/custom/head-end.html` | Hugo Pipes injection with fingerprinted CSS link |
| `site/layouts/_markup/render-codeblock.html` | Render hook extending Hextra's with terminal frame and lineNos defaults |
| `.gitignore` | Add `site/_vendor/` |

## How it works

- Render hook intercepts all fenced code blocks site-wide (R4). No markdown edits needed.
- Code fences with `{filename="path/to/file"}` render a terminal frame header with traffic-light dots (R3)
- `lineNos: inline` is set as default (user overrides via `linenos=false/true`), producing `.line` spans for CSS hover targeting (R5)
- `.ln` spans hidden by CSS; `linenos=true` switches to table mode with visible gutter (R6)
- `hl_lines` passes through to Chroma unchanged (R7)
- Diff blocks get colored `.gi`/`.gd` backgrounds from catppuccin theme (R8)
- Comments render italic + muted from catppuccin definitions (R2)

## Test plan

- [ ] `hugo build` succeeds with zero errors across all 138 pages
- [ ] Code blocks show catppuccin-latte colors in light mode
- [ ] Code blocks show catppuccin-mocha colors in dark mode
- [ ] Dark/light toggle updates colors correctly
- [ ] Copy button functional on all code blocks
- [ ] `filename` attribute renders terminal frame header (add to a test page)
- [ ] `hl_lines` highlights specified lines
- [ ] `linenos=true` shows line number gutter
- [ ] Line hover works on individual lines

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. Changes are build-time only (CSS and Hugo templates) with no runtime dependencies. Visual verification via the deployed GitHub Pages site after merge.