### PR TITLE
feat(docs): add AFDocs compliance for agent-friendly documentation

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -29,6 +29,7 @@ cache = true
 "AGENTS.md" = ["MD041"]
 "docs/guide/**" = ["MD025", "MD063"]
 "docs/reference/**" = ["MD041", "MD063"]
+"site/layouts/**" = ["MD041"]
 "ARCHITECTURE.md" = ["MD063"]
 
 # --- Heading rules ---

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -61,9 +61,11 @@ outputs:
   home:
     - html
     - llms
+    - markdown
     - rss
   section:
     - html
+    - markdown
     - rss
   page:
     - html

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -54,9 +54,25 @@ menu:
       url: https://pkg.go.dev/github.com/armstrongl/nd
       weight: 3
 
+outputs:
+  home:
+    - html
+    - llms
+    - rss
+  section:
+    - html
+    - rss
+  page:
+    - html
+    - markdown
+
 params:
+  description: "nd is a CLI tool for managing and deploying AI coding agent assets (skills, rules, context, commands, hooks, output styles, agents, and plugins) across tools like Claude Code."
   navbar:
     displayTitle: true
     displayLogo: false
   footer:
     displayPoweredBy: false
+  page:
+    contextMenu:
+      enable: true

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -1,6 +1,9 @@
 baseURL: https://armstrongl.github.io/nd/
 title: nd
 enableRobotsTXT: true
+disableKinds:
+  - taxonomy
+  - term
 
 module:
   hugoVersion:

--- a/site/layouts/home.markdown.md
+++ b/site/layouts/home.markdown.md
@@ -1,0 +1,2 @@
+{{- .Site.Title | printf "# %s" }}
+{{ .Site.Params.description }}

--- a/site/layouts/llms.txt
+++ b/site/layouts/llms.txt
@@ -1,14 +1,25 @@
 # {{ .Site.Title }}
 
 > {{ .Site.Params.description }}
+{{ with .OutputFormats.Get "markdown" }}
+- [Home]({{ .Permalink }}){{ end }}
+{{ $docs := site.GetPage "/docs" }}
+{{- with $docs }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $docs.Title }}]({{ .Permalink }}){{ end }}{{ end }}
 
 ## Guide
 {{ $guide := site.GetPage "/docs/guide" }}
+{{- with $guide }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $guide.Title }}]({{ .Permalink }}){{ end }}{{ end }}
+{{- range $guide.Sections }}{{ $sec := . }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $sec.Title }}]({{ .Permalink }}){{ with $sec.Params.description }}: {{ . }}{{ end }}{{ end }}{{ end }}
 {{- range $guide.RegularPagesRecursive.ByWeight }}{{ $page := . }}{{ with .OutputFormats.Get "markdown" }}
 - [{{ $page.Title }}]({{ .Permalink }}){{ with $page.Params.description }}: {{ . }}{{ end }}{{ end }}{{ end }}
 
 ## Reference
 {{ $ref := site.GetPage "/docs/reference" }}
+{{- with $ref }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $ref.Title }}]({{ .Permalink }}){{ end }}{{ end }}
 {{- range $ref.RegularPagesRecursive.ByWeight }}{{ $page := . }}{{ with .OutputFormats.Get "markdown" }}
 - [{{ $page.Title }}]({{ .Permalink }}){{ with $page.Params.description }}: {{ . }}{{ end }}{{ end }}{{ end }}
 

--- a/site/layouts/llms.txt
+++ b/site/layouts/llms.txt
@@ -11,3 +11,8 @@
 {{ $ref := site.GetPage "/docs/reference" }}
 {{- range $ref.RegularPagesRecursive.ByWeight }}{{ $page := . }}{{ with .OutputFormats.Get "markdown" }}
 - [{{ $page.Title }}]({{ .Permalink }}){{ with $page.Params.description }}: {{ . }}{{ end }}{{ end }}{{ end }}
+
+## About
+{{ $about := site.GetPage "/docs/about" }}
+{{- with $about }}{{ $page := . }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $page.Title }}]({{ .Permalink }}){{ end }}{{ end }}

--- a/site/layouts/llms.txt
+++ b/site/layouts/llms.txt
@@ -1,0 +1,13 @@
+# {{ .Site.Title }}
+
+> {{ .Site.Params.description }}
+
+## Guide
+{{ $guide := site.GetPage "/docs/guide" }}
+{{- range $guide.RegularPagesRecursive.ByWeight }}{{ $page := . }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $page.Title }}]({{ .Permalink }}){{ with $page.Params.description }}: {{ . }}{{ end }}{{ end }}{{ end }}
+
+## Reference
+{{ $ref := site.GetPage "/docs/reference" }}
+{{- range $ref.RegularPagesRecursive.ByWeight }}{{ $page := . }}{{ with .OutputFormats.Get "markdown" }}
+- [{{ $page.Title }}]({{ .Permalink }}){{ with $page.Params.description }}: {{ . }}{{ end }}{{ end }}{{ end }}

--- a/site/layouts/partials/custom/footer.html
+++ b/site/layouts/partials/custom/footer.html
@@ -1,0 +1,1 @@
+<div style="display:none">For AI agents: see {{ "llms.txt" | absURL }} for a structured index of this documentation.</div>

--- a/site/layouts/partials/custom/head-end.html
+++ b/site/layouts/partials/custom/head-end.html
@@ -1,0 +1,2 @@
+<meta name="llms-txt" content="{{ "llms.txt" | absURL }}">
+<meta name="agent-directive" content="For AI agents: see {{ "llms.txt" | absURL }} for a structured index of this documentation.">

--- a/site/layouts/section.markdown.md
+++ b/site/layouts/section.markdown.md
@@ -1,0 +1,2 @@
+{{- .Title | replaceRE "\n" " " | printf "# %s" }}
+{{ .RawContent | replaceRE `(?s)\{\{[<%].*` "" | strings.TrimSpace }}


### PR DESCRIPTION
## Summary

Makes nd's documentation site agent-friendly by activating Hugo's built-in output formats and adding a custom llms.txt template per the [AFDocs spec](https://afdocs.dev/) and [llmstxt.org](https://llmstxt.org/) standard.

## What changed

### 1. Hugo output format activation (`site/hugo.yaml`)

- Added `outputs` configuration: `home` generates HTML + llms.txt + RSS; `page` generates HTML + markdown; `section` generates HTML + RSS only (section index pages use shortcodes that render as raw syntax in `.RawContent`, so they are deliberately excluded from markdown output)
- Added `params.description` for the llms.txt subtitle line
- Enabled `params.page.contextMenu` to activate Hextra's "View as Markdown" button on every docs page, giving users a built-in discovery mechanism for `.md` URLs

### 2. Custom llms.txt template (`site/layouts/llms.txt`)

Overrides Hextra's vendored template to produce a spec-compliant index with:
- **Guide section**: 16 leaf pages with titles and `description` from frontmatter, ordered by `weight`. Includes pages nested in `asset-types/` subsection via `.RegularPagesRecursive`
- **Reference section**: 36 individual command pages with titles and descriptions, ordered by `weight`
- **Absolute `.md` URLs**: Uses `.OutputFormats.Get "markdown" | .Permalink` to construct URLs like `https://armstrongl.github.io/nd/docs/guide/getting-started.md` — more robust than string manipulation and guaranteed correct by Hugo's output format system
- **Graceful missing descriptions**: `{{ with .Params.description }}` guard prevents empty `: ` suffixes for pages without descriptions

### 3. Agent directive (`site/layouts/partials/custom/footer.html`)

Injects a hidden `<div style="display:none">` into every page's footer with a directive pointing AI agents to `llms.txt`. Uses Hugo's `absURL` function for the URL. Invisible to human visitors but server-rendered in HTML for agent consumption.

## What this means

AI agents can now:
- **Discover** nd's docs via `llms.txt` at the site root, following the llmstxt.org standard
- **Consume** individual doc pages as clean markdown (frontmatter stripped, title as H1) via `.md` URLs
- **Find** the index via hidden directives embedded in every HTML page

No changes to existing HTML pages, RSS feed, CI/CD pipeline, or docs content. Hugo generates all new outputs during its normal build step, and the existing `site/**` trigger path covers the new layout files.

## Verification

- `hugo build` and `hugo build --minify` succeed
- `llms.txt`: 7,295 bytes (well under 50K limit), 52 links all resolving to existing `.md` files
- No `.md` output for section index pages (shortcode contamination avoided)
- Agent directive present in HTML source of home, guide, and reference pages
- `.md` files have H1 title, no YAML frontmatter

## Test plan

- [ ] `hugo build` completes without errors
- [ ] `site/public/llms.txt` exists with correct structure (H1 title, blockquote description, Guide and Reference sections)
- [ ] All `.md` URLs in llms.txt resolve to existing files in `site/public/`
- [ ] Leaf pages have `.md` files; section index pages do not
- [ ] HTML pages contain hidden agent directive with correct llms.txt URL
- [ ] `hugo build --minify` does not corrupt plain text outputs
- [ ] Deploy to GitHub Pages and run AFDocs checker against live site