### PR TITLE
refactor(release): switch from homebrew_casks to brews

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,13 +33,12 @@ changelog:
     - title: Other
       order: 999
 
-homebrew_casks:
-  - name: nd
-    binaries:
-      - nd
-    repository:
+brews:
+  - repository:
       owner: armstrongl
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/armstrongl/nd
     description: Coding agent asset management CLI tool
+    install: |
+      bin.install "nd"


### PR DESCRIPTION
## Summary

- Replace `homebrew_casks` with `brews` in `.goreleaser.yaml`

## Why

Casks are for GUI applications. For CLI tools, Homebrew formulae are standard and automatically strip the macOS quarantine extended attribute (`com.apple.quarantine`) during installation. This prevents Gatekeeper from blocking the unsigned `nd` binary.

Users install with `brew install armstrongl/tap/nd` (no `--cask` flag).

## Dependencies

- armstrongl/homebrew-tap PR to remove old cask files and add `Formula/` directory

## Test plan

- [ ] Merge both PRs (this + homebrew-tap)
- [ ] Cut a new release and verify GoReleaser writes `Formula/nd.rb` to the tap repo
- [ ] Run `brew install armstrongl/tap/nd` and confirm no quarantine warning