### PR TITLE
docs: structural navigation improvements (Phase 1)

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,7 +48,7 @@ Asset references can be:
   # Script-friendly: skip prompts, output JSON
   nd deploy skills/greeting --yes --json`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,how-nd-works,asset-types/context",
+			"docs.guides": "getting-started,how-nd-works,profiles-and-snapshots,creating-sources,asset-types/context",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,7 +48,8 @@ Asset references can be:
   # Script-friendly: skip prompts, output JSON
   nd deploy skills/greeting --yes --json`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,how-nd-works,profiles-and-snapshots,creating-sources,asset-types/context",
+			"docs.guides":  "getting-started,how-nd-works,profiles-and-snapshots,creating-sources,asset-types/context",
+			"docs.related": "nd remove,nd list,nd status",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -23,7 +23,8 @@ func newDoctorCmd(app *App) *cobra.Command {
   # Output as JSON for CI
   nd doctor --json`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,troubleshooting",
+			"docs.guides":  "getting-started,troubleshooting",
+			"docs.related": "nd status,nd sync",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -219,6 +219,9 @@ func newExportMarketplaceCmd(app *App) *cobra.Command {
 Each --plugins path must point to a directory containing a .claude-plugin/plugin.json file.`,
 		Example: `  # Generate marketplace from exported plugins
   nd export marketplace --plugins ./plugin-a,./plugin-b --output ./marketplace`,
+		Annotations: map[string]string{
+			"docs.guides": "creating-sources,asset-types/plugins",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -54,6 +54,12 @@ func generateCommandDocs(root *cobra.Command, outDir string) error {
 
 	cmds := allCommands(root)
 
+	// Build command lookup map for docs.related cross-links.
+	cmdLookup := make(map[string]*cobra.Command, len(cmds))
+	for _, c := range cmds {
+		cmdLookup[c.CommandPath()] = c
+	}
+
 	// Build sorted names for stable weight assignment.
 	names := make([]string, 0, len(cmds))
 	for _, c := range cmds {
@@ -114,6 +120,32 @@ func generateCommandDocs(root *cobra.Command, outDir string) error {
 			description = c.CommandPath()
 		}
 		frontMatter := fmt.Sprintf("---\ntitle: %q\ndescription: %q\nweight: %d\n---\n", c.CommandPath(), description, weight)
+		// Append semantic cross-links from Annotations["docs.related"].
+		if related, ok := c.Annotations["docs.related"]; ok && related != "" {
+			// Trim trailing blank line so Cobra-generated and docs.related entries
+			// form one continuous list under ## Related.
+			for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+				out = out[:len(out)-1]
+			}
+			for _, path := range strings.Split(related, ",") {
+				path = strings.TrimSpace(path)
+				if path == "" {
+					continue
+				}
+				target, found := cmdLookup[path]
+				if !found {
+					fmt.Fprintf(os.Stderr, "warning: docs.related %q on %s: command not found, skipping\n", path, c.CommandPath())
+					continue
+				}
+				fname := strings.ReplaceAll(path, " ", "_") + ".md"
+				desc := target.Short
+				if desc == "" {
+					desc = path
+				}
+				out = append(out, fmt.Sprintf("- [%s](%s) - %s\n", path, fname, desc))
+			}
+			out = append(out, "\n")
+		}
 		// Append guide cross-links from Annotations["docs.guides"].
 		if guides, ok := c.Annotations["docs.guides"]; ok && guides != "" {
 			out = append(out, "## Guides\n\n")

--- a/cmd/gendocs/main_test.go
+++ b/cmd/gendocs/main_test.go
@@ -26,10 +26,24 @@ func newTestCommandTree() *cobra.Command {
 		Use:   "deploy <widget> [flags]",
 		Short: "Deploy widgets",
 		Long:  "Deploy one or more widgets by creating symlinks.",
-		Run:   noop,
+		Annotations: map[string]string{
+			"docs.related": "testcli remove,testcli profile",
+		},
+		Run: noop,
 	}
 	deploy.Flags().Bool("force", false, "force deployment")
 	root.AddCommand(deploy)
+
+	remove := &cobra.Command{
+		Use:   "remove <widget>",
+		Short: "Remove deployed widgets",
+		Long:  "Remove one or more deployed widgets.",
+		Annotations: map[string]string{
+			"docs.related": "testcli deploy",
+		},
+		Run: noop,
+	}
+	root.AddCommand(remove)
 
 	profile := &cobra.Command{
 		Use:   "profile",
@@ -65,6 +79,7 @@ func TestGenerateCommandDocs_FrontMatter(t *testing.T) {
 	}{
 		{"testcli.md", "testcli"},
 		{"testcli_deploy.md", "testcli deploy"},
+		{"testcli_remove.md", "testcli remove"},
 		{"testcli_profile.md", "testcli profile"},
 		{"testcli_profile_create.md", "testcli profile create"},
 	}
@@ -216,6 +231,7 @@ func TestGenerateCommandDocs_FileNaming(t *testing.T) {
 	expectedFiles := []string{
 		"testcli.md",
 		"testcli_deploy.md",
+		"testcli_remove.md",
 		"testcli_profile.md",
 		"testcli_profile_create.md",
 	}
@@ -250,6 +266,7 @@ func TestGenerateCommandDocs_TitleMatchesCommandPath(t *testing.T) {
 	}{
 		{"testcli.md", "testcli"},
 		{"testcli_deploy.md", "testcli deploy"},
+		{"testcli_remove.md", "testcli remove"},
 		{"testcli_profile.md", "testcli profile"},
 		{"testcli_profile_create.md", "testcli profile create"},
 	}
@@ -292,6 +309,147 @@ func TestGenerateCommandDocs_ConfigDefaultOverridden(t *testing.T) {
 	}
 	if !strings.Contains(text, "~/.config/") {
 		t.Error("testcli.md: expected config flag default to use ~/.config/ tilde path")
+	}
+}
+
+func TestGenerateCommandDocs_DocsRelated_HappyPath(t *testing.T) {
+	outDir := t.TempDir()
+	root := newTestCommandTree()
+
+	if err := generateCommandDocs(root, outDir); err != nil {
+		t.Fatalf("generateCommandDocs failed: %v", err)
+	}
+
+	// deploy has docs.related: "testcli remove,testcli profile"
+	content, err := os.ReadFile(filepath.Join(outDir, "testcli_deploy.md"))
+	if err != nil {
+		t.Fatalf("failed to read testcli_deploy.md: %v", err)
+	}
+	text := string(content)
+
+	if !strings.Contains(text, "## Related") {
+		t.Error("testcli_deploy.md: expected ## Related section")
+	}
+	if !strings.Contains(text, "[testcli remove](testcli_remove.md) - Remove deployed widgets") {
+		t.Error("testcli_deploy.md: expected docs.related link to testcli remove")
+	}
+	if !strings.Contains(text, "[testcli profile](testcli_profile.md) - Manage profiles") {
+		t.Error("testcli_deploy.md: expected docs.related link to testcli profile")
+	}
+}
+
+func TestGenerateCommandDocs_DocsRelated_UnknownCommand(t *testing.T) {
+	outDir := t.TempDir()
+	root := &cobra.Command{
+		Use:   "testcli",
+		Short: "A test CLI tool",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	root.DisableAutoGenTag = true
+
+	orphan := &cobra.Command{
+		Use:   "orphan",
+		Short: "Orphan command",
+		Annotations: map[string]string{
+			"docs.related": "testcli nonexistent",
+		},
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(orphan)
+
+	// Must not crash; the unknown reference is silently skipped (with stderr warning).
+	if err := generateCommandDocs(root, outDir); err != nil {
+		t.Fatalf("generateCommandDocs failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(outDir, "testcli_orphan.md"))
+	if err != nil {
+		t.Fatalf("failed to read testcli_orphan.md: %v", err)
+	}
+	text := string(content)
+
+	// The nonexistent command must NOT appear as a link.
+	if strings.Contains(text, "testcli nonexistent") {
+		t.Error("testcli_orphan.md: should not contain link to nonexistent command")
+	}
+}
+
+func TestGenerateCommandDocs_DocsRelated_EmptyValue(t *testing.T) {
+	outDir := t.TempDir()
+	root := &cobra.Command{
+		Use:   "testcli",
+		Short: "A test CLI tool",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	root.DisableAutoGenTag = true
+
+	empty := &cobra.Command{
+		Use:   "empty",
+		Short: "Empty related",
+		Annotations: map[string]string{
+			"docs.related": "",
+		},
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(empty)
+
+	if err := generateCommandDocs(root, outDir); err != nil {
+		t.Fatalf("generateCommandDocs failed: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(outDir, "testcli_empty.md"))
+	if err != nil {
+		t.Fatalf("failed to read testcli_empty.md: %v", err)
+	}
+	text := string(content)
+
+	// Empty docs.related should NOT add any extra links beyond what Cobra generates.
+	body := bodyAfterFrontMatter(text)
+	// Count link lines — should only have the Cobra-generated parent link.
+	var linkCount int
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "- [") {
+			linkCount++
+		}
+	}
+	// The "empty" subcommand gets a Cobra-generated link back to "testcli".
+	if linkCount != 1 {
+		t.Errorf("testcli_empty.md: expected 1 link (Cobra parent), got %d", linkCount)
+	}
+}
+
+func TestGenerateCommandDocs_DocsRelated_CombinedWithCobraLinks(t *testing.T) {
+	outDir := t.TempDir()
+	root := newTestCommandTree()
+
+	if err := generateCommandDocs(root, outDir); err != nil {
+		t.Fatalf("generateCommandDocs failed: %v", err)
+	}
+
+	// deploy has a Cobra-generated parent link to "testcli" AND docs.related links.
+	content, err := os.ReadFile(filepath.Join(outDir, "testcli_deploy.md"))
+	if err != nil {
+		t.Fatalf("failed to read testcli_deploy.md: %v", err)
+	}
+	text := string(content)
+
+	// Must have Cobra-generated parent link.
+	if !strings.Contains(text, "(testcli.md)") {
+		t.Error("testcli_deploy.md: expected Cobra-generated parent link to testcli.md")
+	}
+	// Must also have docs.related links.
+	if !strings.Contains(text, "(testcli_remove.md)") {
+		t.Error("testcli_deploy.md: expected docs.related link to testcli_remove.md")
+	}
+	if !strings.Contains(text, "(testcli_profile.md)") {
+		t.Error("testcli_deploy.md: expected docs.related link to testcli_profile.md")
+	}
+
+	// All links should be under a single ## Related section.
+	body := bodyAfterFrontMatter(text)
+	relatedCount := strings.Count(body, "## Related")
+	if relatedCount != 1 {
+		t.Errorf("testcli_deploy.md: expected exactly 1 '## Related' heading, got %d", relatedCount)
 	}
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,7 @@ func newListCmd(app *App) *cobra.Command {
   # Output as JSON for scripting
   nd list --json`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,asset-types/skills,asset-types/agents,asset-types/commands,asset-types/rules",
+			"docs.guides": "getting-started,creating-sources,asset-types/skills,asset-types/agents,asset-types/commands,asset-types/rules",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,8 @@ func newListCmd(app *App) *cobra.Command {
   # Output as JSON for scripting
   nd list --json`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,creating-sources,asset-types/skills,asset-types/agents,asset-types/commands,asset-types/rules",
+			"docs.guides":  "getting-started,creating-sources,asset-types/skills,asset-types/agents,asset-types/commands,asset-types/rules",
+			"docs.related": "nd deploy",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -17,7 +17,8 @@ func newPinCmd(app *App) *cobra.Command {
   # Pin using only the name
   nd pin greeting`,
 		Annotations: map[string]string{
-			"docs.guides": "profiles-and-snapshots",
+			"docs.guides":  "profiles-and-snapshots",
+			"docs.related": "nd unpin,nd deploy",
 		},
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,7 +38,8 @@ func newUnpinCmd(app *App) *cobra.Command {
 		Example: `  # Unpin an asset
   nd unpin skills/greeting`,
 		Annotations: map[string]string{
-			"docs.guides": "profiles-and-snapshots",
+			"docs.guides":  "profiles-and-snapshots",
+			"docs.related": "nd pin,nd deploy",
 		},
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -52,7 +52,7 @@ func newProfileCreateCmd(app *App) *cobra.Command {
   # Create a profile for project scope
   nd profile create my-setup --scope project`,
 		Annotations: map[string]string{
-			"docs.guides": "profiles-and-snapshots",
+			"docs.guides": "profiles-and-snapshots,getting-started",
 		},
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -28,7 +28,8 @@ func newRemoveCmd(app *App) *cobra.Command {
   # Preview what would be removed
   nd remove skills/greeting --dry-run`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,how-nd-works,profiles-and-snapshots",
+			"docs.guides":  "getting-started,how-nd-works,profiles-and-snapshots",
+			"docs.related": "nd deploy,nd status",
 		},
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -28,7 +28,7 @@ func newRemoveCmd(app *App) *cobra.Command {
   # Preview what would be removed
   nd remove skills/greeting --dry-run`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started",
+			"docs.guides": "getting-started,how-nd-works,profiles-and-snapshots",
 		},
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -13,6 +13,9 @@ func newSettingsCmd(app *App) *cobra.Command {
 		Use:     "settings",
 		Short:   "Manage nd settings",
 		Example: `  nd settings edit`,
+		Annotations: map[string]string{
+			"docs.guides": "configuration",
+		},
 	}
 
 	cmd.AddCommand(newSettingsEditCmd(app))
@@ -26,7 +29,7 @@ func newSettingsEditCmd(app *App) *cobra.Command {
 		Example: `  # Open config in your default editor
   nd settings edit`,
 		Annotations: map[string]string{
-			"docs.guides": "configuration,asset-types/hooks,asset-types/output-styles",
+			"docs.guides": "configuration,getting-started,troubleshooting,asset-types/hooks,asset-types/output-styles",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/snapshot.go
+++ b/cmd/snapshot.go
@@ -41,7 +41,7 @@ func newSnapshotSaveCmd(app *App) *cobra.Command {
 		Example: `  # Save current deployments as a snapshot
   nd snapshot save before-update`,
 		Annotations: map[string]string{
-			"docs.guides": "profiles-and-snapshots",
+			"docs.guides": "profiles-and-snapshots,getting-started",
 		},
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,7 +21,7 @@ func newStatusCmd(app *App) *cobra.Command {
   # Show project-scope deployments
   nd status --scope project`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started",
+			"docs.guides": "getting-started,troubleshooting",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,7 +21,8 @@ func newStatusCmd(app *App) *cobra.Command {
   # Show project-scope deployments
   nd status --scope project`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,troubleshooting",
+			"docs.guides":  "getting-started,troubleshooting",
+			"docs.related": "nd doctor,nd deploy",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -23,7 +23,8 @@ func newSyncCmd(app *App) *cobra.Command {
   # Preview what would be repaired
   nd sync --dry-run`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started,creating-sources,troubleshooting",
+			"docs.guides":  "getting-started,creating-sources,troubleshooting",
+			"docs.related": "nd source add,nd status",
 		},
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -20,7 +20,7 @@ func newUninstallCmd(app *App) *cobra.Command {
   # Skip confirmation prompt
   nd uninstall --yes`,
 		Annotations: map[string]string{
-			"docs.guides": "getting-started",
+			"docs.guides": "getting-started,troubleshooting",
 		},
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/guide/asset-types/agents.md
+++ b/docs/guide/asset-types/agents.md
@@ -13,6 +13,8 @@ tags:
   - deployment
 ---
 
+Use agents when you want to define a distinct persona or set of instructions that shapes how a coding agent behaves across an entire session. Unlike rules, which enforce individual constraints, an agent file provides holistic behavioral identity.
+
 Agents are single-file assets that define the behavior, persona, or instructions for a named coding agent.
 
 ## Directory layout

--- a/docs/guide/asset-types/agents.md
+++ b/docs/guide/asset-types/agents.md
@@ -31,7 +31,7 @@ Each agent is a markdown file containing agent instructions, a system prompt, or
 
 ## Deploy behavior
 
-nd symlinks the individual file into the target location. Running `nd deploy agents/researcher` produces:
+nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `agents/researcher` produces:
 
 ```text
 ~/.claude/agents/researcher.md → <source>/agents/researcher.md
@@ -44,9 +44,14 @@ nd symlinks the individual file into the target location. Running `nd deploy age
 | Global | `~/.claude/agents/<name>.md` |
 | Project | `.claude/agents/<name>.md` |
 
+To undeploy an agent, run [`nd remove`](../../reference/nd_remove.md) `agents/researcher`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Rules](rules.md) — enforce individual constraints rather than defining a full persona
+- [Context](context.md) — provide broad project knowledge the agent reads automatically
+- [Glossary: Agent](../glossary.md#agent-asset-type) — terminology definition
 
 ## Create an agent
 

--- a/docs/guide/asset-types/commands.md
+++ b/docs/guide/asset-types/commands.md
@@ -31,7 +31,7 @@ Each command is a markdown file whose base filename becomes the slash command na
 
 ## Deploy behavior
 
-nd symlinks the individual file into the target location. Running `nd deploy commands/deploy-all` produces:
+nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `commands/deploy-all` produces:
 
 ```text
 ~/.claude/commands/deploy-all.md → <source>/commands/deploy-all.md
@@ -44,9 +44,14 @@ nd symlinks the individual file into the target location. Running `nd deploy com
 | Global | `~/.claude/commands/<name>.md` |
 | Project | `.claude/commands/<name>.md` |
 
+To undeploy a command, run [`nd remove`](../../reference/nd_remove.md) `commands/deploy-all`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Skills](skills.md) — multi-file directory assets for complex, multi-step behaviors
+- [Agents](agents.md) — define a full persona or instruction set for the coding agent
+- [Glossary: Command](../glossary.md#command) — terminology definition
 
 ## Create a command
 

--- a/docs/guide/asset-types/commands.md
+++ b/docs/guide/asset-types/commands.md
@@ -13,6 +13,8 @@ tags:
   - deployment
 ---
 
+Use commands when you want to give your agent a repeatable action you can trigger on demand with a slash command. Unlike context or rules, which apply passively, a command runs only when you explicitly invoke it.
+
 Commands are single-file assets that define custom slash commands available to coding agents during a session.
 
 ## Directory layout

--- a/docs/guide/asset-types/context.md
+++ b/docs/guide/asset-types/context.md
@@ -47,9 +47,9 @@ target_agent: "claude-code"
 
 ## Deploy behavior
 
-Context assets deploy to **fixed paths determined by the context filename**, not into a `context/` subdirectory. This differs from all other asset types.
+Context assets deploy to **fixed paths determined by the context filename**, not into a `context/` subdirectory. This differs from all other asset types — see [How nd works](../how-nd-works.md#context-files-the-exception) for details on context deployment.
 
-For a context asset whose context file is `CLAUDE.md`:
+Running [`nd deploy`](../../reference/nd_deploy.md) on a context asset whose context file is `CLAUDE.md`:
 
 - At global scope, nd symlinks to `~/.claude/CLAUDE.md`
 - At project scope, nd symlinks to `./CLAUDE.md` at the project root — not inside `.claude/`
@@ -64,9 +64,14 @@ Files named `*.local.md` are treated as local-only and deploy at project scope r
 | Project | `./<filename>` (project root) |
 | Local (`*.local.md`) | `./<filename>` (project scope only) |
 
+To undeploy a context asset, run [`nd remove`](../../reference/nd_remove.md) `context/go-standards`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Rules](rules.md) — enforce individual constraints rather than broad project knowledge
+- [Agents](agents.md) — define a full persona or instruction set for the coding agent
+- [Glossary: Context file](../glossary.md#context-file) — terminology definition
 
 ## Create a context asset
 

--- a/docs/guide/asset-types/context.md
+++ b/docs/guide/asset-types/context.md
@@ -15,6 +15,8 @@ tags:
   - conflicts
 ---
 
+Use context when you want project-wide conventions or persistent instructions that the agent reads automatically at the start of every session. Unlike rules, which state individual constraints, context provides broad project knowledge such as architecture decisions, coding standards, or team workflows.
+
 Context assets provide persistent instructions or project conventions to coding agents, deployed to fixed paths derived from the context filename rather than into a type subdirectory.
 
 ## Directory layout

--- a/docs/guide/asset-types/hooks.md
+++ b/docs/guide/asset-types/hooks.md
@@ -41,7 +41,7 @@ The `event` field names the agent lifecycle event that triggers the hook. Script
 
 ## Deploy behavior
 
-nd symlinks the hook directory into the target scope directory. After deployment, you must manually register the hook in your agent's `settings.json` to activate it. nd prints a reminder after deploying this asset type.
+nd symlinks the hook directory into the target scope directory (see [How nd works](../how-nd-works.md) for details on the symlink strategy). After running [`nd deploy`](../../reference/nd_deploy.md), you must manually register the hook in your agent's `settings.json` to activate it. nd prints a reminder after deploying this asset type.
 
 ## Scope rules
 
@@ -54,9 +54,14 @@ nd symlinks the hook directory into the target scope directory. After deployment
 
 After running `nd deploy`, open your agent's `settings.json` and add the hook to the hooks configuration. For Claude Code, hooks are registered under the `hooks` key, keyed by event name.
 
+To undeploy a hook, run [`nd remove`](../../reference/nd_remove.md) `hooks/lint-check`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Output styles](output-styles.md) — another asset type that requires manual `settings.json` registration
+- [Plugins](plugins.md) — bundle multiple assets into a distributable package
+- [Glossary: Hook](../glossary.md#hook) — terminology definition
 
 ## Create a hook
 

--- a/docs/guide/asset-types/hooks.md
+++ b/docs/guide/asset-types/hooks.md
@@ -13,6 +13,8 @@ tags:
   - deployment
 ---
 
+Use hooks when you want to run scripts automatically in response to agent lifecycle events, such as linting before a tool executes or logging after a response completes. Unlike commands, which require manual invocation, hooks fire automatically when their event occurs.
+
 Hooks are directory assets that define event-driven automation triggered by agent lifecycle events, deployed as symlinked directories and activated via manual `settings.json` registration.
 
 ## Directory layout

--- a/docs/guide/asset-types/output-styles.md
+++ b/docs/guide/asset-types/output-styles.md
@@ -36,7 +36,7 @@ Maximum 3 sentences per response.
 
 ## Deploy behavior
 
-nd symlinks the `.md` file into the target scope directory. After deployment, you must manually add the style to your agent's `settings.json` to activate it. nd prints a reminder after deploying this asset type.
+nd symlinks the `.md` file into the target scope directory (see [How nd works](../how-nd-works.md) for details on the symlink strategy). After running [`nd deploy`](../../reference/nd_deploy.md), you must manually add the style to your agent's `settings.json` to activate it. nd prints a reminder after deploying this asset type.
 
 ## Scope rules
 
@@ -49,9 +49,14 @@ nd symlinks the `.md` file into the target scope directory. After deployment, yo
 
 After running `nd deploy`, open your agent's `settings.json` and add the style to the output styles configuration. The exact key depends on your agent; for Claude Code it lives under the `outputStyles` array.
 
+To undeploy an output style, run [`nd remove`](../../reference/nd_remove.md) `output-styles/concise`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Hooks](hooks.md) — another asset type that requires manual `settings.json` registration
+- [Rules](rules.md) — constrain agent behavior broadly, complementing output-specific formatting
+- [Glossary: Output style](../glossary.md#output-style) — terminology definition
 
 ## Create an output style
 

--- a/docs/guide/asset-types/output-styles.md
+++ b/docs/guide/asset-types/output-styles.md
@@ -13,6 +13,8 @@ tags:
   - deployment
 ---
 
+Use output styles when you want to control how the agent formats its responses — for example, terse bullet points for experienced users or detailed explanations for learners. Unlike rules, which constrain agent behavior broadly, output styles focus specifically on presentation and tone.
+
 Output styles are single-file assets that define formatting instructions for agent output, deployed as symlinks and activated via manual `settings.json` registration.
 
 ## Directory layout

--- a/docs/guide/asset-types/plugins.md
+++ b/docs/guide/asset-types/plugins.md
@@ -48,7 +48,7 @@ Asset subdirectories inside the plugin (e.g., `skills/`, `commands/`) follow the
 
 ## Deploy behavior
 
-Plugins are **not deployable via `nd deploy`**. Instead, use `nd export` to package the assets you want to include, then install the exported package through your agent's plugin installation mechanism.
+Plugins are **not deployable via `nd deploy`**. Instead, use [`nd export`](../../reference/nd_export.md) to package the assets you want to include, then install the exported package through your agent's plugin installation mechanism.
 
 ```shell
 nd export --assets skills/greeting,commands/hello --output ./my-plugin
@@ -60,9 +60,14 @@ The exported directory is a self-contained plugin that can be handed off, versio
 
 Not applicable. Plugins bypass the symlink deployment system entirely and have no global or project scope path.
 
+You can also generate a marketplace listing with [`nd export marketplace`](../../reference/nd_export_marketplace.md).
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Skills](skills.md) — multi-file directory assets commonly bundled inside plugins
+- [Commands](commands.md) — single-file assets commonly bundled inside plugins
+- [Glossary: Plugin](../glossary.md#plugin) — terminology definition
 
 ## Create a plugin
 

--- a/docs/guide/asset-types/plugins.md
+++ b/docs/guide/asset-types/plugins.md
@@ -71,7 +71,9 @@ You can also generate a marketplace listing with [`nd export marketplace`](../..
 
 ## Create a plugin
 
-Create the plugin directory structure inside your source:
+### Author a plugin in your source
+
+Create the plugin directory structure inside your source. A plugin needs a `.claude-plugin/plugin.json` manifest and at least one nested asset:
 
 ```shell
 mkdir -p ~/my-assets/plugins/my-toolbox/.claude-plugin
@@ -90,4 +92,8 @@ Greet the user by name with a short, friendly message.
 EOF
 ```
 
-Once your source is registered (`nd source add ~/my-assets`), nd discovers the plugin and its nested assets. To package assets from any source into a standalone plugin for distribution, use `nd export` — see the [nd export reference](../../reference/nd_export.md).
+Once your source is registered (`nd source add ~/my-assets`), nd discovers the plugin and its nested assets.
+
+### Package assets for distribution
+
+To package individual assets from any source into a standalone plugin for distribution, use [`nd export`](../../reference/nd_export.md). This creates a new plugin directory from the assets you select — it does not require an existing `plugins/` directory as input. See the [nd export reference](../../reference/nd_export.md) for details.

--- a/docs/guide/asset-types/plugins.md
+++ b/docs/guide/asset-types/plugins.md
@@ -14,6 +14,8 @@ tags:
   - export
 ---
 
+Use plugins when you want to package several related assets into a single distributable unit that others can install. Unlike deploying individual assets with `nd deploy`, plugins are exported as self-contained packages via `nd export`.
+
 Plugins are directory assets that bundle multiple nd assets into a Claude Code plugin package, distributed and installed via the `nd export` workflow rather than symlink deployment.
 
 ## Directory layout

--- a/docs/guide/asset-types/rules.md
+++ b/docs/guide/asset-types/rules.md
@@ -33,7 +33,7 @@ Each rule is a markdown file whose base filename describes the constraint it enc
 
 ## Deploy behavior
 
-nd symlinks the individual file into the target location. Running `nd deploy rules/no-emojis` produces:
+nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `rules/no-emojis` produces:
 
 ```text
 ~/.claude/rules/no-emojis.md → <source>/rules/no-emojis.md
@@ -46,9 +46,14 @@ nd symlinks the individual file into the target location. Running `nd deploy rul
 | Global | `~/.claude/rules/<name>.md` |
 | Project | `.claude/rules/<name>.md` |
 
+To undeploy a rule, run [`nd remove`](../../reference/nd_remove.md) `rules/no-emojis`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Context](context.md) — provide broad project knowledge rather than individual constraints
+- [Agents](agents.md) — define a full persona that bundles multiple behavioral instructions
+- [Glossary: Rule](../glossary.md#rule) — terminology definition
 
 ## Create a rule
 

--- a/docs/guide/asset-types/rules.md
+++ b/docs/guide/asset-types/rules.md
@@ -13,6 +13,8 @@ tags:
   - deployment
 ---
 
+Use rules when you want to enforce a specific constraint or convention that the agent must follow in every interaction — such as "never use emojis" or "always write tests." Unlike context, which provides broad project knowledge, each rule targets a single, enforceable behavior.
+
 Rules are assets that define behavioral constraints or conventions a coding agent must follow throughout a session. A rule can be a single Markdown file or a directory.
 
 ## Directory layout

--- a/docs/guide/asset-types/skills.md
+++ b/docs/guide/asset-types/skills.md
@@ -13,6 +13,8 @@ tags:
   - deployment
 ---
 
+Use skills when you want to teach the agent a complex, multi-step behavior that may need supporting files like examples, templates, or reference data. Unlike commands, which are single-file slash-command instructions, skills bundle everything the agent needs into one deployable directory.
+
 Skills are multi-file directory assets that package reusable coding-agent behaviors into a named, self-contained directory.
 
 ## Directory layout

--- a/docs/guide/asset-types/skills.md
+++ b/docs/guide/asset-types/skills.md
@@ -35,7 +35,7 @@ The entry point is a file named `SKILL.md` at the root of the skill directory (e
 
 ## Deploy behavior
 
-nd symlinks the entire skill directory into the target location. Running `nd deploy skills/greeting` produces:
+nd symlinks the entire skill directory into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `skills/greeting` produces:
 
 ```text
 ~/.claude/skills/greeting → <source>/skills/greeting
@@ -50,9 +50,14 @@ The agent sees the full directory contents through the symlink.
 | Global | `~/.claude/skills/<name>` |
 | Project | `.claude/skills/<name>` |
 
+To undeploy a skill, run [`nd remove`](../../reference/nd_remove.md) `skills/greeting`.
+
 ## Related
 
 - [Asset type comparison](../creating-sources.md#asset-types) for a side-by-side overview of all types
+- [Commands](commands.md) — single-file slash-command assets for simpler, on-demand actions
+- [Plugins](plugins.md) — bundle skills and other assets into a distributable package
+- [Glossary: Skill](../glossary.md#skill) — terminology definition
 
 ## Create a skill
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -24,7 +24,7 @@ nd uses YAML configuration files with a layered merging system.
 | Project | `.nd/config.yaml` | Project-specific overrides |
 | CLI flag | `--config <path>` | One-time override |
 
-`nd init` creates the global config. Project-level config is optional.
+[`nd init`](../reference/nd_init.md) creates the global config. Project-level config is optional.
 
 ## Data directories
 
@@ -143,13 +143,13 @@ If you have not set `$EDITOR` or `$VISUAL`, `nd settings edit` uses `vi`.
 
 ## Edit config
 
-Open your config in your default editor:
+Open your config in your default editor with [`nd settings edit`](../reference/nd_settings_edit.md):
 
 ```shell
 nd settings edit
 ```
 
-After editing, validate your config:
+After editing, validate your config with [`nd doctor`](../reference/nd_doctor.md):
 
 ```shell
 nd doctor
@@ -217,3 +217,11 @@ cat ~/.config/nd/logs/operations.log | jq -r '.operation' | sort | uniq -c | sor
 nd rotates the log file automatically when it exceeds 1 MB. nd preserves the previous log as `operations.log.1` and keeps only one rotated backup.
 
 Dry-run operations (`--dry-run`) do not write log entries.
+
+## Next steps
+
+- **[Get started](getting-started.md):** Install nd and deploy your first asset
+- **[User guide](user-guide.md):** Core workflows for deploying, removing, and managing assets
+- **[Creating sources](creating-sources.md):** Structure your own asset directories for nd to discover
+- **[`nd settings` reference](../reference/nd_settings.md):** Full reference for the settings command
+- **[Troubleshooting](troubleshooting.md):** Fix configuration problems, broken symlinks, and other issues

--- a/docs/guide/creating-sources.md
+++ b/docs/guide/creating-sources.md
@@ -107,7 +107,7 @@ git remote add origin https://github.com/you/my-assets.git
 git push -u origin main
 ```
 
-Others can add it with:
+Others can add it with [`nd source add`](../reference/nd_source_add.md):
 
 ```shell
 nd source add you/my-assets
@@ -115,9 +115,11 @@ nd source add you/my-assets
 nd source add https://github.com/you/my-assets.git
 ```
 
-nd clones git sources to `~/.config/nd/sources/`. Sync them with `nd sync --source <id>`.
+nd clones git sources to `~/.config/nd/sources/`. Sync them with [`nd sync`](../reference/nd_sync.md) `--source <id>`.
 
 ## Remove a source
+
+Remove a registered source with [`nd source remove`](../reference/nd_source_remove.md):
 
 ```shell
 nd source remove <source-id>
@@ -126,3 +128,11 @@ nd source remove <source-id>
 If assets from the source are currently deployed, nd asks whether to remove them, keep them as orphans, or cancel. nd prevents removal of the `builtin` source.
 
 > **Warning:** `nd source remove <id> --yes` skips the interactive prompt and **removes all deployed assets** from that source without confirmation. This is a destructive operation — use it only in scripts or when you are certain you want a clean removal.
+
+## Next steps
+
+- **[How nd works](how-nd-works.md):** Understand what happens on disk when assets are deployed as symlinks
+- **[User guide](user-guide.md):** Core workflows for deploying, removing, and managing assets from your sources
+- **[Profiles and snapshots](profiles-and-snapshots.md):** Group assets into named profiles and switch between them
+- **[`nd source` reference](../reference/nd_source.md):** Full flag and option reference for all source subcommands
+- **[Troubleshooting](troubleshooting.md):** Fix missing assets, broken symlinks, and source scanning issues

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ go install github.com/armstrongl/nd@latest
 git clone https://github.com/armstrongl/nd.git && cd nd && go build -o nd .
 ```
 
-Verify the installation:
+Verify the installation with [`nd version`](../reference/nd_version.md):
 
 ```shell
 nd version
@@ -61,13 +61,13 @@ nd init
 
 This creates `~/.config/nd/config.yaml` with sensible defaults and sets up directories for profiles, snapshots, and state.
 
-`nd init` then prompts you to deploy nd's built-in assets (skills, commands, and an agent). Answer **y** to deploy them immediately so you have something to work with, or **n** to skip — you can deploy them later with `nd deploy --source builtin`. Pass `--yes` to skip the prompt entirely and deploy automatically.
+[`nd init`](../reference/nd_init.md) then prompts you to deploy nd's built-in assets (skills, commands, and an agent). Answer **y** to deploy them immediately so you have something to work with, or **n** to skip — you can deploy them later with [`nd deploy`](../reference/nd_deploy.md) `--source builtin`. Pass `--yes` to skip the prompt entirely and deploy automatically.
 
 If nd cannot detect your coding agent (e.g., Claude Code is not installed or not in `$PATH`), it skips the built-in deploy with a warning and continues. Install your agent and run `nd deploy --source builtin` afterward.
 
-If a config file already exists, `nd init` exits with an error. Use `nd settings edit` to modify an existing configuration.
+If a config file already exists, `nd init` exits with an error. Use [`nd settings edit`](../reference/nd_settings_edit.md) to modify an existing configuration.
 
-Browse the built-in assets:
+Browse the built-in assets with [`nd list`](../reference/nd_list.md):
 
 ```shell
 nd list
@@ -75,7 +75,7 @@ nd list
 
 ## 3. Add your first source
 
-nd ships with a **builtin** source containing nd-specific assets. To add your own assets, register a **source**: a local directory or git repository containing agent assets organized by type.
+nd ships with a **builtin** source containing nd-specific assets. To add your own assets, register a **source** with [`nd source add`](../reference/nd_source_add.md): a local directory or git repository containing agent assets organized by type.
 
 ```shell
 # Local directory
@@ -120,7 +120,7 @@ Deploy multiple assets at once:
 nd deploy skills/greeting commands/hello agents/researcher
 ```
 
-Or run `nd deploy` with no arguments to get an interactive picker. Many nd commands support this interactive mode — `nd remove`, `nd profile switch`, `nd snapshot restore`, and others present a picker when run without arguments. nd disables interactive mode in non-TTY environments (pipes, scripts) and when `--json` is set.
+Or run `nd deploy` with no arguments to get an interactive picker. Many nd commands support this interactive mode — [`nd remove`](../reference/nd_remove.md), [`nd profile switch`](../reference/nd_profile_switch.md), [`nd snapshot restore`](../reference/nd_snapshot_restore.md), and others present a picker when run without arguments. nd disables interactive mode in non-TTY environments (pipes, scripts) and when `--json` is set.
 
 nd creates a symlink from your agent's config directory (`~/.claude/skills/greeting`) back to the source. The source stays where it is: edit it and the change shows up immediately. See [How nd works](how-nd-works.md) for the full picture of what happens on disk.
 
@@ -152,7 +152,7 @@ Change the default strategy in your config file (`symlink_strategy: relative`).
 
 ## 6. Verify
 
-Check that everything is healthy:
+Check that everything is healthy with [`nd status`](../reference/nd_status.md):
 
 ```shell
 nd status
@@ -160,7 +160,7 @@ nd status
 
 The output shows your deployed assets with health indicators (checkmarks for healthy symlinks).
 
-For a full health check:
+For a full health check, run [`nd doctor`](../reference/nd_doctor.md):
 
 ```shell
 nd doctor
@@ -170,7 +170,7 @@ nd doctor
 
 ### Shell completions
 
-Enable tab-completion for your shell:
+Enable tab-completion for your shell with [`nd completion`](../reference/nd_completion.md):
 
 ```shell
 # Print completion script
@@ -204,7 +204,7 @@ nd settings edit
 
 ## Uninstall
 
-To remove all nd-managed symlinks from your agent's config directory:
+To remove all nd-managed symlinks from your agent's config directory, run [`nd uninstall`](../reference/nd_uninstall.md):
 
 ```shell
 nd uninstall

--- a/docs/guide/how-nd-works.md
+++ b/docs/guide/how-nd-works.md
@@ -16,7 +16,7 @@ tags:
 
 nd doesn't copy files. It creates symlinks.
 
-When you run `nd deploy skills/greeting`, nd creates a symlink from your agent's config directory back to the original source. The source stays where it is. Edit the source, and the change shows up instantly in the deployed location: no redeploy needed.
+When you run [`nd deploy`](../reference/nd_deploy.md) `skills/greeting`, nd creates a symlink from your agent's config directory back to the original source. The source stays where it is. Edit the source, and the change shows up instantly in the deployed location: no redeploy needed.
 
 ## The mental model
 
@@ -157,4 +157,8 @@ For everything else, deploy and go: no additional nd configuration required.
 
 ## Next steps
 
-- **[Profiles and snapshots](profiles-and-snapshots.md):** Group assets into named profiles and switch between them without touching individual symlinks.
+- **[User guide](user-guide.md):** Core workflows for deploying, removing, and managing assets
+- **[Profiles and snapshots](profiles-and-snapshots.md):** Group assets into named profiles and switch between them without touching individual symlinks
+- **[Creating sources](creating-sources.md):** Structure your own asset directories for nd to discover
+- **[`nd deploy` reference](../reference/nd_deploy.md):** Full flag and option reference for the deploy command
+- **[Troubleshooting](troubleshooting.md):** Fix broken symlinks, missing assets, and other common issues

--- a/docs/guide/profiles-and-snapshots.md
+++ b/docs/guide/profiles-and-snapshots.md
@@ -26,7 +26,7 @@ A **profile** is a named collection of assets: like browser profiles for your co
 
 ### From an asset list
 
-Specify exactly which assets belong in the profile:
+Specify exactly which assets belong in the profile with [`nd profile create`](../reference/nd_profile_create.md):
 
 ```shell
 nd profile create work --assets skills/enterprise-auth,skills/jira-integration,agents/code-reviewer
@@ -48,7 +48,7 @@ nd profile create work --from-current --description "Enterprise development setu
 
 ## Build profiles incrementally
 
-Add assets to an existing profile one at a time:
+Add assets to an existing profile one at a time with [`nd profile add-asset`](../reference/nd_profile_add-asset.md):
 
 ```shell
 nd profile add-asset work skills/new-skill
@@ -56,6 +56,8 @@ nd profile add-asset work commands/deploy-staging
 ```
 
 ## List profiles
+
+List all profiles with [`nd profile list`](../reference/nd_profile_list.md):
 
 ```shell
 nd profile list
@@ -65,7 +67,7 @@ nd marks the active profile with `*`.
 
 ## Deploy a profile
 
-Deploy all assets from a profile:
+Deploy all assets from a profile with [`nd profile deploy`](../reference/nd_profile_deploy.md):
 
 ```shell
 nd profile deploy work
@@ -81,7 +83,7 @@ nd profile deploy work --dry-run
 
 ## Switch profiles
 
-Switch from the current active profile to another:
+Switch from the current active profile to another with [`nd profile switch`](../reference/nd_profile_switch.md):
 
 ```shell
 nd profile switch personal
@@ -96,6 +98,8 @@ This shows a diff preview of what changes:
 Before switching, nd automatically saves a snapshot (safety net). After confirming, it removes old profile assets and deploys new ones.
 
 ## Delete profiles
+
+Delete a profile with [`nd profile delete`](../reference/nd_profile_delete.md):
 
 ```shell
 nd profile delete work
@@ -115,6 +119,8 @@ nd pin skills/greeting
 nd unpin skills/greeting
 ```
 
+See the [`nd pin`](../reference/nd_pin.md) and [`nd unpin`](../reference/nd_unpin.md) reference pages for full details.
+
 When switching profiles, nd skips pinned assets entirely: nd neither removes nor redeploys them.
 
 ## Snapshots
@@ -123,11 +129,15 @@ A **snapshot** is a point-in-time record of all current deployments. Think of it
 
 ### Save a snapshot
 
+Save a snapshot with [`nd snapshot save`](../reference/nd_snapshot_save.md):
+
 ```shell
 nd snapshot save before-experiment
 ```
 
 ### List snapshots
+
+List all snapshots with [`nd snapshot list`](../reference/nd_snapshot_list.md):
 
 ```shell
 nd snapshot list
@@ -136,6 +146,8 @@ nd snapshot list
 The list shows both user-created and auto-created snapshots. nd tags auto-snapshots (created before destructive operations) with `(auto)`.
 
 ### Restore a snapshot
+
+Restore a snapshot with [`nd snapshot restore`](../reference/nd_snapshot_restore.md):
 
 ```shell
 nd snapshot restore before-experiment
@@ -146,6 +158,8 @@ This removes all current deployments and redeploys the snapshot's assets. nd sav
 Run `nd snapshot restore` with no arguments to get an interactive picker.
 
 ### Delete a snapshot
+
+Delete a snapshot with [`nd snapshot delete`](../reference/nd_snapshot_delete.md):
 
 ```shell
 nd snapshot delete old-snapshot
@@ -187,3 +201,11 @@ nd profile switch work
 ```
 
 Pinned assets (`skills/greeting`, `rules/no-emojis`) persist through every switch.
+
+## Next steps
+
+- **[How nd works](how-nd-works.md):** Understand symlinks, scopes, and what happens on disk
+- **[User guide](user-guide.md):** Core workflows for deploying, removing, and listing assets
+- **[Configuration](configuration.md):** Customize default scope, symlink strategy, and other settings
+- **[`nd profile` reference](../reference/nd_profile.md):** Full flag and option reference for all profile subcommands
+- **[Troubleshooting](troubleshooting.md):** Fix profile switch problems, missing assets, and other issues

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -14,7 +14,7 @@ tags:
   - doctor
 ---
 
-Start with `nd doctor` to identify the category of problem, then find the matching section below.
+Start with [`nd doctor`](../reference/nd_doctor.md) to identify the category of problem, then find the matching section below.
 
 ## Run nd doctor
 
@@ -40,7 +40,7 @@ nd doctor --json
 
 ## Broken symlinks
 
-**Symptoms:** `nd status` shows unhealthy assets with an `✗` indicator. `nd doctor` reports deployment issues.
+**Symptoms:** [`nd status`](../reference/nd_status.md) shows unhealthy assets with an `✗` indicator. `nd doctor` reports deployment issues.
 
 **Common causes:**
 
@@ -50,6 +50,8 @@ nd doctor --json
 - Source was removed from nd but symlinks remain
 
 **Fix:**
+
+Use [`nd sync`](../reference/nd_sync.md) to repair broken symlinks:
 
 ```shell
 # Repair all broken symlinks
@@ -67,7 +69,7 @@ nd doctor
 
 ## Missing assets
 
-**Symptoms:** `nd list` does not show expected assets. `nd source list` shows the source but it reports zero assets.
+**Symptoms:** [`nd list`](../reference/nd_list.md) does not show expected assets. [`nd source list`](../reference/nd_source_list.md) shows the source but it reports zero assets.
 
 **Common causes:**
 
@@ -88,7 +90,7 @@ ls <source-path>/
 nd settings edit
 ```
 
-The expected directory names are: `skills/`, `agents/`, `commands/`, `output-styles/`, `rules/`, `context/`, `plugins/`, `hooks/`. See [Create asset sources](creating-sources.md) for the full convention.
+Use [`nd settings edit`](../reference/nd_settings_edit.md) to fix source paths. The expected directory names are: `skills/`, `agents/`, `commands/`, `output-styles/`, `rules/`, `context/`, `plugins/`, `hooks/`. See [Create asset sources](creating-sources.md) for the full convention.
 
 ## Configuration problems
 
@@ -140,7 +142,7 @@ nd unpin skills/greeting
 nd profile add-asset my-setup skills/greeting
 ```
 
-The `nd status` output shows the origin of each asset: `manual`, `pinned`, or the profile name. Only assets with a profile origin are managed during switches. See [Profiles and snapshots](profiles-and-snapshots.md) for the full workflow.
+The `nd status` output shows the origin of each asset: `manual`, `pinned`, or the profile name. Use [`nd unpin`](../reference/nd_unpin.md) to release pinned assets back to profile management, or [`nd profile add-asset`](../reference/nd_profile_add-asset.md) to add missing assets to a profile. Only assets with a profile origin are managed during switches. See [Profiles and snapshots](profiles-and-snapshots.md) for the full workflow.
 
 ## Context file conflicts
 
@@ -185,7 +187,7 @@ nd settings edit
 
 ## Ambiguous asset name
 
-**Symptoms:** `nd deploy greeting` fails with `ambiguous asset "greeting" — matches: ...`
+**Symptoms:** [`nd deploy`](../reference/nd_deploy.md) `greeting` fails with `ambiguous asset "greeting" — matches: ...`
 
 **Cause:** Multiple assets share the same name across different types or sources (e.g., `skills/greeting` and `commands/greeting`).
 
@@ -205,7 +207,7 @@ nd deploy --type skills greeting
 
 **Symptoms:** A command fails with `confirmation required but stdin is not a terminal (use --yes to skip)`.
 
-**Cause:** nd requires interactive confirmation for destructive operations (remove, uninstall, profile switch). In non-TTY environments (pipes, scripts, CI), there is no terminal to prompt.
+**Cause:** nd requires interactive confirmation for destructive operations ([`nd remove`](../reference/nd_remove.md), [`nd uninstall`](../reference/nd_uninstall.md), profile switch). In non-TTY environments (pipes, scripts, CI), there is no terminal to prompt.
 
 **Fix:** Pass `--yes` to skip the confirmation:
 
@@ -215,7 +217,7 @@ nd source remove my-assets --yes
 
 ## Config already exists
 
-**Symptoms:** `nd init` fails with `config already exists at ~/.config/nd/config.yaml; edit with 'nd settings edit'`.
+**Symptoms:** [`nd init`](../reference/nd_init.md) fails with `config already exists at ~/.config/nd/config.yaml; edit with 'nd settings edit'`.
 
 **Cause:** nd has already been initialized. `nd init` refuses to overwrite an existing config to prevent accidental data loss.
 
@@ -227,7 +229,7 @@ rm ~/.config/nd/config.yaml && nd init
 
 ## No active profile
 
-**Symptoms:** `nd profile deploy` (with no name argument) fails with `no active profile; use 'nd profile deploy <name>' instead`.
+**Symptoms:** [`nd profile deploy`](../reference/nd_profile_deploy.md) (with no name argument) fails with `no active profile; use 'nd profile deploy <name>' instead`.
 
 **Cause:** You ran `nd profile deploy` without specifying a profile name, and no profile is currently active. nd only knows which profile to redeploy if one was previously activated.
 
@@ -237,7 +239,7 @@ rm ~/.config/nd/config.yaml && nd init
 nd profile deploy my-setup
 ```
 
-Or switch to a profile first with `nd profile switch my-setup`.
+Or switch to a profile first with [`nd profile switch`](../reference/nd_profile_switch.md) `my-setup`.
 
 ## Deploy conflict
 
@@ -259,3 +261,11 @@ For context files specifically, nd automatically backs up the existing file to `
 **Symptoms:** `nd doctor` reports git is not available. `nd sync` cannot pull git sources.
 
 **Fix:** Install git and ensure it is in your `$PATH`. On macOS, `xcode-select --install` installs git. On Linux, use your package manager (`apt install git`, `dnf install git`).
+
+## Related pages
+
+- **[`nd doctor` reference](../reference/nd_doctor.md):** Full flag and option reference for the doctor command
+- **[`nd sync` reference](../reference/nd_sync.md):** Full reference for repairing symlinks and pulling git sources
+- **[Configuration](configuration.md):** Config file locations, merging order, and all available settings
+- **[How nd works](how-nd-works.md):** Understand symlinks, scopes, and what happens on disk
+- **[Profiles and snapshots](profiles-and-snapshots.md):** Profile switching, pinning, and snapshot workflows

--- a/docs/guide/user-guide.md
+++ b/docs/guide/user-guide.md
@@ -18,10 +18,10 @@ This guide covers the core workflows for managing assets with nd.
 
 Many nd commands support running without arguments to get an interactive picker. This works for:
 
-- `nd deploy`: pick assets to deploy
-- `nd remove`: pick deployed assets to remove
-- `nd profile delete` / `switch` / `deploy`: pick a profile
-- `nd snapshot delete` / `restore`: pick a snapshot
+- [`nd deploy`](../reference/nd_deploy.md): pick assets to deploy
+- [`nd remove`](../reference/nd_remove.md): pick deployed assets to remove
+- [`nd profile delete`](../reference/nd_profile_delete.md) / [`switch`](../reference/nd_profile_switch.md) / [`deploy`](../reference/nd_profile_deploy.md): pick a profile
+- [`nd snapshot delete`](../reference/nd_snapshot_delete.md) / [`restore`](../reference/nd_snapshot_restore.md): pick a snapshot
 
 Interactive mode is automatically disabled in non-TTY environments (pipes, scripts) and when `--json` is set. In those cases, nd returns an error with a helpful message.
 
@@ -50,6 +50,8 @@ nd deploy skills/greeting --yes --json | jq '.status'
 
 ### Add a local directory
 
+Add a source with [`nd source add`](../reference/nd_source_add.md):
+
 ```shell
 nd source add ~/my-assets
 nd source add ~/my-assets --alias my-stuff
@@ -74,6 +76,8 @@ Git sources are cloned to `~/.config/nd/sources/` and can be synced later.
 
 ### List sources
 
+List registered sources with [`nd source list`](../reference/nd_source_list.md):
+
 ```shell
 nd source list
 ```
@@ -82,7 +86,7 @@ Output shows source ID, type (`local`, `git`, or `builtin`), asset count, and pa
 
 ### Sync git sources
 
-Pull the latest changes from a git source:
+Pull the latest changes from a git source with [`nd sync`](../reference/nd_sync.md):
 
 ```shell
 nd sync --source <source-id>
@@ -91,6 +95,8 @@ nd sync --source <source-id>
 This runs `git pull --ff-only` and then repairs any broken symlinks.
 
 ### Remove a source
+
+Remove a source with [`nd source remove`](../reference/nd_source_remove.md):
 
 ```shell
 nd source remove <source-id>
@@ -158,6 +164,8 @@ Run `nd remove` with no arguments to get an interactive picker of deployed asset
 
 ### List available assets
 
+Use [`nd list`](../reference/nd_list.md) to browse assets:
+
 ```shell
 # All assets
 nd list
@@ -175,6 +183,8 @@ nd list --pattern greeting
 Assets marked with `*` are currently deployed.
 
 ### Check deployment status
+
+Run [`nd status`](../reference/nd_status.md) to see what is deployed:
 
 ```shell
 nd status
@@ -196,7 +206,7 @@ nd status --json
 
 ## Settings
 
-Open your config file in your default editor (`$EDITOR`, `$VISUAL`, or `vi`):
+Open your config file in your default editor (`$EDITOR`, `$VISUAL`, or `vi`) with [`nd settings edit`](../reference/nd_settings_edit.md):
 
 ```shell
 nd settings edit
@@ -226,7 +236,7 @@ nd sync --dry-run
 
 ## Health checks
 
-Run a comprehensive health check:
+Run a comprehensive health check with [`nd doctor`](../reference/nd_doctor.md):
 
 ```shell
 nd doctor
@@ -280,7 +290,7 @@ Dry-run operations (`--dry-run`) do not write log entries.
 
 ## Shell completions
 
-Generate and install shell completions:
+Generate and install shell completions with [`nd completion`](../reference/nd_completion.md):
 
 ```shell
 # Print completion script
@@ -306,10 +316,18 @@ autoload -Uz compinit && compinit
 
 ## Uninstall
 
-Remove all nd-managed symlinks from agent config directories:
+Remove all nd-managed symlinks from agent config directories with [`nd uninstall`](../reference/nd_uninstall.md):
 
 ```shell
 nd uninstall
 ```
 
 This removes symlinks but does **not** delete your config directory (`~/.config/nd/`). To fully uninstall, also remove that directory and the nd binary.
+
+## Next steps
+
+- **[How nd works](how-nd-works.md):** Understand what happens on disk when you deploy and remove assets
+- **[Profiles and snapshots](profiles-and-snapshots.md):** Group assets into named profiles and switch between them
+- **[Creating sources](creating-sources.md):** Build and share your own asset libraries
+- **[Configuration](configuration.md):** Customize nd behavior, config merging, and global flags
+- **[Troubleshooting](troubleshooting.md):** Fix broken symlinks, missing assets, and other common issues

--- a/docs/guide/user-guide.md
+++ b/docs/guide/user-guide.md
@@ -104,6 +104,8 @@ nd source remove <source-id>
 
 If assets from this source are currently deployed, nd asks whether to remove them, keep them as orphans, or cancel. The `builtin` source cannot be removed.
 
+> **Warning:** `nd source remove <id> --yes` skips the interactive prompt and **removes all deployed assets** from that source without confirmation. This is a destructive operation — use it only in scripts or when you are certain you want a clean removal.
+
 ## Deploy assets
 
 For a visual walkthrough of what deploy does on disk, see [How nd works](how-nd-works.md).

--- a/docs/reference/nd_deploy.md
+++ b/docs/reference/nd_deploy.md
@@ -68,6 +68,9 @@ nd deploy <asset> [assets...] [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd remove](nd_remove.md) - Remove deployed assets
+- [nd list](nd_list.md) - List available assets from all sources
+- [nd status](nd_status.md) - Show deployment status and health
 
 ## Guides
 

--- a/docs/reference/nd_deploy.md
+++ b/docs/reference/nd_deploy.md
@@ -73,4 +73,6 @@ nd deploy <asset> [assets...] [flags]
 
 - [Getting started](../guide/getting-started.md)
 - [How nd works](../guide/how-nd-works.md)
+- [Profiles and snapshots](../guide/profiles-and-snapshots.md)
+- [Create sources](../guide/creating-sources.md)
 - [Context files](../guide/asset-types/context.md)

--- a/docs/reference/nd_doctor.md
+++ b/docs/reference/nd_doctor.md
@@ -42,6 +42,8 @@ nd doctor [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd status](nd_status.md) - Show deployment status and health
+- [nd sync](nd_sync.md) - Repair symlinks and optionally pull git sources
 
 ## Guides
 

--- a/docs/reference/nd_export_marketplace.md
+++ b/docs/reference/nd_export_marketplace.md
@@ -52,3 +52,8 @@ nd export marketplace [flags]
 ## Related
 
 - [nd export](nd_export.md) - Export assets as a Claude Code plugin
+
+## Guides
+
+- [Create sources](../guide/creating-sources.md)
+- [Plugins](../guide/asset-types/plugins.md)

--- a/docs/reference/nd_list.md
+++ b/docs/reference/nd_list.md
@@ -58,6 +58,7 @@ nd list [flags]
 ## Guides
 
 - [Getting started](../guide/getting-started.md)
+- [Create sources](../guide/creating-sources.md)
 - [Skills](../guide/asset-types/skills.md)
 - [Agents](../guide/asset-types/agents.md)
 - [Commands](../guide/asset-types/commands.md)

--- a/docs/reference/nd_list.md
+++ b/docs/reference/nd_list.md
@@ -54,6 +54,7 @@ nd list [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd deploy](nd_deploy.md) - Deploy assets by creating symlinks
 
 ## Guides
 

--- a/docs/reference/nd_pin.md
+++ b/docs/reference/nd_pin.md
@@ -42,6 +42,8 @@ nd pin <asset> [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd unpin](nd_unpin.md) - Unpin an asset, allowing profile switches to manage it
+- [nd deploy](nd_deploy.md) - Deploy assets by creating symlinks
 
 ## Guides
 

--- a/docs/reference/nd_profile_create.md
+++ b/docs/reference/nd_profile_create.md
@@ -49,3 +49,4 @@ nd profile create <name> [flags]
 ## Guides
 
 - [Profiles and snapshots](../guide/profiles-and-snapshots.md)
+- [Getting started](../guide/getting-started.md)

--- a/docs/reference/nd_remove.md
+++ b/docs/reference/nd_remove.md
@@ -48,6 +48,8 @@ nd remove <asset> [assets...] [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd deploy](nd_deploy.md) - Deploy assets by creating symlinks
+- [nd status](nd_status.md) - Show deployment status and health
 
 ## Guides
 

--- a/docs/reference/nd_remove.md
+++ b/docs/reference/nd_remove.md
@@ -52,3 +52,5 @@ nd remove <asset> [assets...] [flags]
 ## Guides
 
 - [Getting started](../guide/getting-started.md)
+- [How nd works](../guide/how-nd-works.md)
+- [Profiles and snapshots](../guide/profiles-and-snapshots.md)

--- a/docs/reference/nd_settings.md
+++ b/docs/reference/nd_settings.md
@@ -35,3 +35,7 @@ Manage nd settings
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
 - [nd settings edit](nd_settings_edit.md) - Open settings in your editor
+
+## Guides
+
+- [Configuration](../guide/configuration.md)

--- a/docs/reference/nd_settings_edit.md
+++ b/docs/reference/nd_settings_edit.md
@@ -43,5 +43,7 @@ nd settings edit [flags]
 ## Guides
 
 - [Configuration](../guide/configuration.md)
+- [Getting started](../guide/getting-started.md)
+- [Troubleshoot](../guide/troubleshooting.md)
 - [Hooks](../guide/asset-types/hooks.md)
 - [Output styles](../guide/asset-types/output-styles.md)

--- a/docs/reference/nd_snapshot_save.md
+++ b/docs/reference/nd_snapshot_save.md
@@ -43,3 +43,4 @@ nd snapshot save <name> [flags]
 ## Guides
 
 - [Profiles and snapshots](../guide/profiles-and-snapshots.md)
+- [Getting started](../guide/getting-started.md)

--- a/docs/reference/nd_status.md
+++ b/docs/reference/nd_status.md
@@ -45,6 +45,8 @@ nd status [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd doctor](nd_doctor.md) - Check nd configuration and deployment health
+- [nd deploy](nd_deploy.md) - Deploy assets by creating symlinks
 
 ## Guides
 

--- a/docs/reference/nd_status.md
+++ b/docs/reference/nd_status.md
@@ -49,3 +49,4 @@ nd status [flags]
 ## Guides
 
 - [Getting started](../guide/getting-started.md)
+- [Troubleshoot](../guide/troubleshooting.md)

--- a/docs/reference/nd_sync.md
+++ b/docs/reference/nd_sync.md
@@ -46,6 +46,8 @@ nd sync [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd source add](nd_source_add.md) - Register a new asset source
+- [nd status](nd_status.md) - Show deployment status and health
 
 ## Guides
 

--- a/docs/reference/nd_uninstall.md
+++ b/docs/reference/nd_uninstall.md
@@ -46,3 +46,4 @@ nd uninstall [flags]
 ## Guides
 
 - [Getting started](../guide/getting-started.md)
+- [Troubleshoot](../guide/troubleshooting.md)

--- a/docs/reference/nd_unpin.md
+++ b/docs/reference/nd_unpin.md
@@ -39,6 +39,8 @@ nd unpin <asset> [flags]
 ## Related
 
 - [nd](nd.md) - Napoleon Dynamite - coding agent asset manager
+- [nd pin](nd_pin.md) - Pin an asset to prevent profile switches from removing it
+- [nd deploy](nd_deploy.md) - Deploy assets by creating symlinks
 
 ## Guides
 


### PR DESCRIPTION
## Summary

- Add "when and why" contextual framing to all 8 asset-type pages
- Expand cross-references and Related sections on asset-type pages (6+ outbound links each)
- Add inline command links and Related/Next steps sections across all 7 guide pages
- Fill gaps in `docs.guides` Cobra annotations (30 reference pages now have Guides sections)
- Implement new `docs.related` annotation in gendocs for semantic command cross-links (deploy↔remove, pin↔unpin, status↔doctor)
- Add destructive-operation warning for `nd source remove --yes` to user-guide.md
- Fix plugins.md "Create a plugin" section: separate authoring from packaging



## Test plan

- [x] `go test ./cmd/gendocs/...` — 12 tests pass (4 new for docs.related)
- [x] `go build -buildvcs=false ./...` — compiles clean
- [x] `go test -buildvcs=false ./...` — all 21 unit test packages pass
- [x] `go run ./cmd/gendocs` — regenerates all reference pages without error
- [x] All asset-type pages have 6+ outbound links
- [x] All guide pages have 3+ Related/Next steps links
- [x] 30/36 reference pages have `## Guides` sections (6 without are utility/meta commands)
- [x] Semantic cross-links verified (nd_deploy.md → nd remove, nd_status.md → nd doctor)
- [x] Markdown lint passes on all commits

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — documentation-only changes with no runtime impact. The gendocs code change is validated by tests and reference page regeneration.