### PR TITLE
docs: comprehensive update for multi-agent support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,7 +111,7 @@ Agent detection and registry.
 
 - `Registry`: Detect installed coding agents, lookup by name, select default
 - `Agent`: Agent metadata: `Name`, `Binary`, `SupportedTypes`, `DefaultContextFile`, `ContextInProjectDir`, `VersionPattern`, global_dir, project_dir, detected, in_path
-- Two built-in agents: `claude-code` (~/.claude) and `copilot-cli` (~/.copilot)
+- Two built-in agents: `claude-code` (~/.claude) and `copilot` (~/.copilot)
 - Binary verification: the registry runs `runCommand` to confirm each agent's binary is installed and reachable
 - Testability: `SetLookPath()` / `SetStat()` / `SetRunCommand()` for injecting stubs
 
@@ -145,8 +145,8 @@ Cobra commands and application wiring.
 
 Bubble Tea v2 dashboard.
 
-- `app/`: Main TUI application
-- `components/`: Reusable UI components (tables, pickers, dialogs)
+- Flat package structure (no subpackages): all screens, list utilities, and theme code live directly under `internal/tui/`
+- `tui.Services` interface decouples TUI from `cmd.App`
 - Dashboard-centric design with tabbed asset views
 
 ## Data Flow Example
@@ -155,7 +155,7 @@ Bubble Tea v2 dashboard.
 
 ```text
 cmd/deploy.go
-  -> app.Agent()                    -- resolve target agent (claude-code, copilot-cli)
+  -> app.Agent()                    -- resolve target agent (claude-code, copilot)
   -> app.SourceManager().Scan()     -- discover assets from all sources
   -> asset.Index.Lookup()           -- find "skills/greeting" in index
   -> app.DeployEngine().Deploy()    -- create symlink, set dep.Agent

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,10 +14,10 @@ nd is a CLI/TUI tool that manages coding agent assets (skills, agents, commands,
 |          internal/tui/ (TUI layer)           |
 +---------------------------------------------+
 | sourcemanager | deploy | profile |   agent   |  <- Service layer
-|            doctor | backup | oplog           |  <- Supporting services
+|      doctor | backup | oplog | updater       |  <- Supporting services
 +---------------------------------------------+
 |  nd  | config | asset | source |    state    |  <- Core types
-|          version | output                    |  <- Utilities
+|       version | output | builtin             |  <- Utilities
 +---------------------------------------------+
 ```
 
@@ -29,44 +29,47 @@ nd is a CLI/TUI tool that manages coding agent assets (skills, agents, commands,
 
 Core enums and constants shared across the codebase.
 
-- `AssetType` -- 8 asset types: skills, agents, commands, output-styles, rules, context, plugins, hooks
-- `Scope` -- `global` (agent-wide) or `project` (repo-specific)
-- `SourceType` -- `local` (directory), `git` (repository), or `builtin` (embedded in binary)
-- `SymlinkStrategy` -- `absolute` or `relative` symlinks
-- `Origin` -- Deployment origin: `manual`, `pinned`, or `profile:<name>`
+- `AssetType`: 8 asset types: skills, agents, commands, output-styles, rules, context, plugins, hooks
+- `Scope`: `global` (agent-wide) or `project` (repo-specific)
+- `SourceType`: `local` (directory), `git` (repository), or `builtin` (embedded in binary)
+- `SymlinkStrategy`: `absolute` or `relative` symlinks
+- `Origin`: Deployment origin: `manual`, `pinned`, or `profile:<name>`
 - Utility functions: `FindProjectRoot()`, `AtomicWrite()`
 
 ### internal/config
 
 Configuration types and validation.
 
-- `Config` -- Top-level config: version, default_scope, default_agent, symlink_strategy, sources, agents
-- `SourceEntry` -- Source registration: id, type, path, url, alias
-- `Config.Validate()` -- Validates config against schema rules
+- `Config`: Top-level config: version, default_scope, default_agent, symlink_strategy, sources, agents
+- `SourceEntry`: Source registration: id, type, path, url, alias
+- `Config.Validate()`: Validates config against schema rules
 - Config merging: defaults -> global -> project -> CLI flags
 
 ### internal/asset
 
 Asset types and indexing.
 
-- `Asset` -- An asset discovered from a source: type, name, path, source ID, metadata
-- `Identity` -- Unique tuple: (source_id, asset_type, asset_name)
-- `Index` -- In-memory asset index with lookup and search
-- `CachedIndex` -- Caching layer over Index for repeated lookups
+- `Asset`: An asset discovered from a source: type, name, path, source ID, metadata
+- `Identity`: Unique tuple: (source_id, asset_type, asset_name)
+- `Index`: In-memory asset index with lookup and search
+- `CachedIndex`: Caching layer over Index for repeated lookups
 
 ### internal/source
 
 Source data types.
 
-- `Source` -- A registered source: ID, type, path, URL, alias, manifest
-- `Manifest` -- Explicit `nd-source.yaml` file defining custom asset paths and exclusions (overrides convention scanning)
+- `Source`: A registered source: ID, type, path, URL, alias, manifest
+- `Manifest`: Explicit `nd-source.yaml` file defining custom asset paths and exclusions (overrides convention scanning)
 
 ### internal/state
 
 Deployment state persistence.
 
-- `Store` -- Load/Save deployment state to YAML files
-- `DeploymentState` -- Tracks all active deployments with health status
+- `Store`: Load/Save deployment state to YAML files
+- `DeploymentState`: Tracks all active deployments with health status
+- Each `Deployment` includes an `Agent` field recording which agent it was deployed for
+- `FindByAgent()`: Query deployments filtered by agent name
+- Schema v2 (`SchemaVersion = 2`): lazy-on-first-mutate migration from v1 adds per-deployment agent tracking
 - File locking for concurrent access safety
 
 ## Service Layer (Middle)
@@ -75,39 +78,57 @@ Deployment state persistence.
 
 Source lifecycle management.
 
-- `SourceManager` -- Config loading, source registration, asset scanning, git syncing
-- `AddLocal()` / `AddGit()` -- Register new sources
-- `Remove()` -- Unregister sources (with deployed asset handling)
-- `ScanSource()` -- Asset discovery: manifest (`nd-source.yaml`) overrides convention; convention used when no manifest present
+- `SourceManager`: Config loading, source registration, asset scanning, git syncing
+- `AddLocal()` / `AddGit()`: Register new sources
+- `Remove()`: Unregister sources (with deployed asset handling)
+- `ScanSource()`: Asset discovery: manifest (`nd-source.yaml`) overrides convention; convention used when no manifest present
 - Git operations: clone, pull (--ff-only)
 
 ### internal/deploy
 
 Symlink deployment engine.
 
-- `Engine` -- Deploy, remove, health check, repair, bulk operations
-- `Deploy()` / `DeployBulk()` -- Create symlinks from agent config dir to source assets
-- `Remove()` / `RemoveBulk()` -- Delete managed symlinks
-- `SetOrigin()` -- Update deployment origin (manual, pinned, profile)
+- `Engine`: Deploy, remove, health check, repair, bulk operations
+- `Deploy()` / `DeployBulk()`: Create symlinks from agent config dir to source assets
+- `Remove()` / `RemoveBulk()`: Delete managed symlinks (accepts `Agent` field for agent-specific removal)
+- `SetOrigin()`: Update deployment origin (manual, pinned, profile)
+- Agent-aware deployment: sets `dep.Agent` to the target agent's name on each deployment record
+- `UnsupportedTypeError`: Returned when an asset type is not in the target agent's `SupportedTypes`
 
 ### internal/profile
 
 Profile and snapshot management.
 
-- `Profile` -- Named collection of assets
-- `Snapshot` -- Point-in-time deployment state record
-- `Store` -- CRUD for profiles and snapshots (YAML files)
-- `Manager` -- Orchestrates `Switch()`, `DeployProfile()`, `Restore()`
+- `Profile`: Named collection of assets
+- `Snapshot`: Point-in-time deployment state record
+- `Store`: CRUD for profiles and snapshots (YAML files)
+- `Manager`: Orchestrates `Switch()`, `DeployProfile()`, `Restore()`
 - Switch diff: calculates which assets to add/remove/keep
 
 ### internal/agent
 
 Agent detection and registry.
 
-- `Registry` -- Detect installed coding agents, lookup by name, select default
-- `Agent` -- Agent metadata: name, global_dir, project_dir, detected, in_path
-- Hardcoded default: `claude-code` (~/.claude)
-- Testability: `SetLookPath()` / `SetStat()` for injecting stubs
+- `Registry`: Detect installed coding agents, lookup by name, select default
+- `Agent`: Agent metadata: `Name`, `Binary`, `SupportedTypes`, `DefaultContextFile`, `ContextInProjectDir`, `VersionPattern`, global_dir, project_dir, detected, in_path
+- Two built-in agents: `claude-code` (~/.claude) and `copilot-cli` (~/.copilot)
+- Binary verification: the registry runs `runCommand` to confirm each agent's binary is installed and reachable
+- Testability: `SetLookPath()` / `SetStat()` / `SetRunCommand()` for injecting stubs
+
+### internal/updater
+
+Update check with caching.
+
+- `CheckCached()`: Reads latest-version info from local cache
+- `RefreshAsync()`: Checks GitHub for new releases in the background
+- `IsNewer()`: Compares semver strings to determine if an update is available
+
+### internal/builtin
+
+Embedded built-in source.
+
+- Uses `embed.FS` to ship default assets inside the nd binary
+- `Path()`: Extracts embedded assets to a versioned cache dir (`~/.cache/nd/builtin/<version>/`)
 
 ## CLI Layer (Top)
 
@@ -115,17 +136,17 @@ Agent detection and registry.
 
 Cobra commands and application wiring.
 
-- `App` -- Central struct with lazily initialized services
-- `NewRootCmd(app *App)` -- Builds the root command with 8 global flags
+- `App`: Central struct with lazily initialized services
+- `NewRootCmd(app *App)`: Builds the root command with 8 global flags
 - One file per command group: `deploy.go`, `remove.go`, `source.go`, `profile.go`, `snapshot.go`, etc.
-- `helpers.go` -- Shared utilities: `confirm()`, `promptChoice()`, `isTerminal()`, `extractChoiceNames()`
+- `helpers.go`: Shared utilities: `confirm()`, `promptChoice()`, `isTerminal()`, `extractChoiceNames()`
 
 ### internal/tui/
 
 Bubble Tea v2 dashboard.
 
-- `app/` -- Main TUI application
-- `components/` -- Reusable UI components (tables, pickers, dialogs)
+- `app/`: Main TUI application
+- `components/`: Reusable UI components (tables, pickers, dialogs)
 - Dashboard-centric design with tabbed asset views
 
 ## Data Flow Example
@@ -134,25 +155,26 @@ Bubble Tea v2 dashboard.
 
 ```text
 cmd/deploy.go
+  -> app.Agent()                    -- resolve target agent (claude-code, copilot-cli)
   -> app.SourceManager().Scan()     -- discover assets from all sources
   -> asset.Index.Lookup()           -- find "skills/greeting" in index
-  -> app.DeployEngine().Deploy()    -- create symlink
+  -> app.DeployEngine().Deploy()    -- create symlink, set dep.Agent
   -> state.Save()                   -- persist deployment record
   -> print confirmation
 ```
 
 ## Key Patterns
 
-- **Atomic writes** -- Config and state files are written atomically (write to temp, rename) to prevent corruption
-- **Config merging** -- Defaults -> global config -> project config -> CLI flags, each layer can override
-- **Convention-based scanning** -- Source directories named `skills/`, `agents/`, etc. are auto-discovered
-- **Test doubles via function injection** -- `agent.SetLookPath()`, `agent.SetStat()` allow injecting stubs without interfaces
-- **Lazy service initialization** -- `App` struct initializes services on first access, not at startup
-- **Origin tracking** -- Each deployment records its origin (manual, pinned, profile:X) for smart profile switching
+- **Atomic writes**: Config and state files are written atomically (write to temp, rename) to prevent corruption
+- **Config merging**: Defaults -> global config -> project config -> CLI flags, each layer can override
+- **Convention-based scanning**: Source directories named `skills/`, `agents/`, etc. are auto-discovered
+- **Test doubles via function injection**: `agent.SetLookPath()`, `agent.SetStat()` allow injecting stubs without interfaces
+- **Lazy service initialization**: `App` struct initializes services on first access, not at startup
+- **Origin tracking**: Each deployment records its origin (manual, pinned, profile:X) for smart profile switching
 
 ## Testing Strategy
 
-- **TDD workflow** -- Red/green/refactor for all business logic
-- **Function injection** -- OS-level operations stubbed via injected functions
-- **Integration tests** -- `tests/integration/` for end-to-end scenarios
-- **Coverage targets** -- 80%+ for business logic, lower acceptable for CLI/TUI interactive paths
+- **TDD workflow**: Red/green/refactor for all business logic
+- **Function injection**: OS-level operations stubbed via injected functions
+- **Integration tests**: `tests/integration/` for end-to-end scenarios
+- **Coverage targets**: 80%+ for business logic, lower acceptable for CLI/TUI interactive paths

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
 > [!WARNING]
 > nd is still in alpha and under active development. Please let me know if you encounter issues 🙂
 
-Manage coding agent assets (skills, agents, commands, rules, and more) across tools like Claude Code with symlink-based deployment.
+Manage coding agent assets (skills, agents, commands, rules, and more) across tools like Claude Code and Copilot CLI with symlink-based deployment.
 
 ![nd demo](assets/napoleon-dynamite-skills.gif)
 
 ## What it does
 
 - **Built-in assets:** Ships with nd-specific skills, commands, and an agent — ready to use after `nd init`
+- **Multi-agent support:** Deploy to Claude Code, Copilot CLI, or other agents with `--agent`
 - **Register sources:** Point nd at local directories or git repos containing agent assets
 - **Deploy assets:** Create symlinks from agent config directories to source assets, keeping everything in sync
 - **Switch profiles:** Group assets into named profiles and switch between them instantly
@@ -102,6 +103,8 @@ Run any command with `--help` for detailed usage, or see the full [Command Refer
 
 Many commands support **interactive mode**: run without arguments to get a picker. Use `--json` for scripted output and `--yes` to skip confirmations.
 
+Use `--agent` to target a specific agent (e.g., `nd deploy --agent copilot`). Without it, nd uses the `default_agent` from your config.
+
 ## Configure
 
 nd uses a YAML config file at `~/.config/nd/config.yaml`. Key settings:
@@ -109,7 +112,7 @@ nd uses a YAML config file at `~/.config/nd/config.yaml`. Key settings:
 ```yaml
 version: 1
 default_scope: global       # or "project"
-default_agent: claude-code
+default_agent: claude-code  # also supports: copilot
 symlink_strategy: absolute  # or "relative"
 ```
 
@@ -122,6 +125,7 @@ See the full [configuration guide](docs/guide/configuration.md).
 - [Profiles & snapshots](docs/guide/profiles-and-snapshots.md): Advanced workflow management
 - [Configuration](docs/guide/configuration.md): Config reference, global flags, operation log
 - [Creating sources](docs/guide/creating-sources.md): Build your own asset library
+- [Glossary](docs/guide/glossary.md): Key terms including multi-agent concepts
 - [Command reference](docs/reference/nd.md): Auto-generated from source
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Manage coding agent assets (skills, agents, commands, rules, and more) across to
 ## What it does
 
 - **Built-in assets:** Ships with nd-specific skills, commands, and an agent — ready to use after `nd init`
-- **Multi-agent support:** Deploy to Claude Code, Copilot CLI, or other agents with `--agent`
+- **Multi-agent support:** Deploy to Claude Code or Copilot CLI with `--agent`
 - **Register sources:** Point nd at local directories or git repos containing agent assets
 - **Deploy assets:** Create symlinks from agent config directories to source assets, keeping everything in sync
 - **Switch profiles:** Group assets into named profiles and switch between them instantly

--- a/docs/guide/asset-types/agents.md
+++ b/docs/guide/asset-types/agents.md
@@ -15,6 +15,8 @@ tags:
 
 Use agents when you want to define a distinct persona or set of instructions that shapes how a coding agent behaves across an entire session. Unlike rules, which enforce individual constraints, an agent file provides holistic behavioral identity.
 
+Both Claude Code and Copilot CLI support agent assets.
+
 Agents are single-file assets that define the behavior, persona, or instructions for a named coding agent.
 
 ## Directory layout
@@ -31,18 +33,22 @@ Each agent is a markdown file containing agent instructions, a system prompt, or
 
 ## Deploy behavior
 
-nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `agents/researcher` produces:
+nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `agents/researcher` produces a symlink in the active agent's config directory:
 
 ```text
+# Claude Code
 ~/.claude/agents/researcher.md → <source>/agents/researcher.md
+
+# Copilot CLI
+~/.copilot/agents/researcher.md → <source>/agents/researcher.md
 ```
 
 ## Scope rules
 
-| Scope | Target path |
-|-------|-------------|
-| Global | `~/.claude/agents/<name>.md` |
-| Project | `.claude/agents/<name>.md` |
+| Scope | Claude Code | Copilot CLI |
+|-------|-------------|-------------|
+| Global | `~/.claude/agents/<name>.md` | `~/.copilot/agents/<name>.md` |
+| Project | `.claude/agents/<name>.md` | `.github/agents/<name>.md` |
 
 To undeploy an agent, run [`nd remove`](../../reference/nd_remove.md) `agents/researcher`.
 

--- a/docs/guide/asset-types/commands.md
+++ b/docs/guide/asset-types/commands.md
@@ -15,6 +15,8 @@ tags:
 
 Use commands when you want to give your agent a repeatable action you can trigger on demand with a slash command. Unlike context or rules, which apply passively, a command runs only when you explicitly invoke it.
 
+Commands are a Claude Code-only asset type. Copilot CLI does not support commands.
+
 Commands are single-file assets that define custom slash commands available to coding agents during a session.
 
 ## Directory layout

--- a/docs/guide/asset-types/context.md
+++ b/docs/guide/asset-types/context.md
@@ -45,7 +45,7 @@ target_project: "my-project"
 target_agent: "claude-code"
 ```
 
-The `target_agent` field controls which coding agent this context asset targets. Set it to `claude-code` (default) or `copilot` to indicate the intended agent. nd uses this when filtering or listing assets.
+The `target_agent` field indicates which coding agent this context asset is intended for. Set it to `claude-code` (default) or `copilot` to document the intended agent for the asset's metadata.
 
 ## Deploy behavior
 

--- a/docs/guide/asset-types/context.md
+++ b/docs/guide/asset-types/context.md
@@ -17,7 +17,7 @@ tags:
 
 Use context when you want project-wide conventions or persistent instructions that the agent reads automatically at the start of every session. Unlike rules, which state individual constraints, context provides broad project knowledge such as architecture decisions, coding standards, or team workflows.
 
-Context assets provide persistent instructions or project conventions to coding agents, deployed to fixed paths derived from the context filename rather than into a type subdirectory.
+Context assets provide persistent instructions or project conventions to coding agents, deployed to fixed paths derived from the target agent's configuration rather than into a type subdirectory.
 
 ## Directory layout
 
@@ -34,7 +34,7 @@ context/
 
 ## File format
 
-The context file (e.g., `CLAUDE.md`) contains the instructions or conventions in plain Markdown. The optional `_meta.yaml` sidecar carries metadata used by nd for listing and filtering.
+The context file (e.g., `CLAUDE.md` or `copilot-instructions.md`) contains the instructions or conventions in plain Markdown. The optional `_meta.yaml` sidecar carries metadata used by nd for listing and filtering.
 
 ```yaml
 # _meta.yaml
@@ -45,24 +45,37 @@ target_project: "my-project"
 target_agent: "claude-code"
 ```
 
+The `target_agent` field controls which coding agent this context asset targets. Set it to `claude-code` (default) or `copilot` to indicate the intended agent. nd uses this when filtering or listing assets.
+
 ## Deploy behavior
 
-Context assets deploy to **fixed paths determined by the context filename**, not into a `context/` subdirectory. This differs from all other asset types — see [How nd works](../how-nd-works.md#context-files-the-exception) for details on context deployment.
+Context assets deploy to **fixed paths determined by the target agent**, not into a `context/` subdirectory. This differs from all other asset types — see [How nd works](../how-nd-works.md#context-files-the-exception) for details on context deployment.
 
-Running [`nd deploy`](../../reference/nd_deploy.md) on a context asset whose context file is `CLAUDE.md`:
+The deploy path depends on which agent nd is targeting:
 
-- At global scope, nd symlinks to `~/.claude/CLAUDE.md`
-- At project scope, nd symlinks to `./CLAUDE.md` at the project root — not inside `.claude/`
+- **Claude Code**: at project scope, nd symlinks to `./CLAUDE.md` at the project root — not inside `.claude/`. At global scope, nd symlinks to `~/.claude/CLAUDE.md`.
+- **Copilot**: at project scope, nd symlinks to `.github/copilot-instructions.md` — inside the agent's project directory, not the project root. At global scope, nd symlinks to `~/.copilot/copilot-instructions.md`.
 
 Files named `*.local.md` are treated as local-only and deploy at project scope regardless of the `--scope` flag.
 
+### Context file renaming
+
+When deploying a context asset to an agent that defines a default context filename, nd automatically renames the deployed file if all of these conditions are met:
+
+1. The agent has a `DefaultContextFile` set (Copilot uses `copilot-instructions.md`; Claude Code does not rename)
+2. The source file's name differs from the agent's default
+3. The asset does not originate from the agent's own source alias
+4. The file is not a `*.local.md` local-only context
+
+For example, deploying a `CLAUDE.md` context asset to Copilot renames the symlink target to `copilot-instructions.md`, ensuring the agent can find it. This means multiple context assets targeting the same agent may collide — nd detects these collisions during bulk deploy and reports an error.
+
 ## Scope rules
 
-| Scope | Target path |
-|-------|-------------|
-| Global | `~/.claude/<filename>` |
-| Project | `./<filename>` (project root) |
-| Local (`*.local.md`) | `./<filename>` (project scope only) |
+| Scope | Claude Code target path | Copilot target path |
+|-------|-------------------------|---------------------|
+| Global | `~/.claude/CLAUDE.md` | `~/.copilot/copilot-instructions.md` |
+| Project | `./CLAUDE.md` (project root) | `.github/copilot-instructions.md` (inside project dir) |
+| Local (`*.local.md`) | `./<filename>` (project scope only) | `.github/<filename>` (project scope only) |
 
 To undeploy a context asset, run [`nd remove`](../../reference/nd_remove.md) `context/go-standards`.
 

--- a/docs/guide/asset-types/hooks.md
+++ b/docs/guide/asset-types/hooks.md
@@ -15,6 +15,8 @@ tags:
 
 Use hooks when you want to run scripts automatically in response to agent lifecycle events, such as linting before a tool executes or logging after a response completes. Unlike commands, which require manual invocation, hooks fire automatically when their event occurs.
 
+Hooks are a Claude Code-only asset type. Copilot CLI does not support hooks.
+
 Hooks are directory assets that define event-driven automation triggered by agent lifecycle events, deployed as symlinked directories and activated via manual `settings.json` registration.
 
 ## Directory layout

--- a/docs/guide/asset-types/output-styles.md
+++ b/docs/guide/asset-types/output-styles.md
@@ -15,6 +15,8 @@ tags:
 
 Use output styles when you want to control how the agent formats its responses — for example, terse bullet points for experienced users or detailed explanations for learners. Unlike rules, which constrain agent behavior broadly, output styles focus specifically on presentation and tone.
 
+Output styles are a Claude Code-only asset type. Copilot CLI does not support output styles.
+
 Output styles are single-file assets that define formatting instructions for agent output, deployed as symlinks and activated via manual `settings.json` registration.
 
 ## Directory layout

--- a/docs/guide/asset-types/rules.md
+++ b/docs/guide/asset-types/rules.md
@@ -15,6 +15,8 @@ tags:
 
 Use rules when you want to enforce a specific constraint or convention that the agent must follow in every interaction — such as "never use emojis" or "always write tests." Unlike context, which provides broad project knowledge, each rule targets a single, enforceable behavior.
 
+Rules are a Claude Code-only asset type. Copilot CLI does not support rules.
+
 Rules are assets that define behavioral constraints or conventions a coding agent must follow throughout a session. A rule can be a single Markdown file or a directory.
 
 ## Directory layout

--- a/docs/guide/asset-types/skills.md
+++ b/docs/guide/asset-types/skills.md
@@ -15,6 +15,8 @@ tags:
 
 Use skills when you want to teach the agent a complex, multi-step behavior that may need supporting files like examples, templates, or reference data. Unlike commands, which are single-file slash-command instructions, skills bundle everything the agent needs into one deployable directory.
 
+Both Claude Code and Copilot CLI support skills.
+
 Skills are multi-file directory assets that package reusable coding-agent behaviors into a named, self-contained directory.
 
 ## Directory layout
@@ -35,20 +37,24 @@ The entry point is a file named `SKILL.md` at the root of the skill directory (e
 
 ## Deploy behavior
 
-nd symlinks the entire skill directory into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `skills/greeting` produces:
+nd symlinks the entire skill directory into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `skills/greeting` produces a symlink in the active agent's config directory:
 
 ```text
+# Claude Code
 ~/.claude/skills/greeting → <source>/skills/greeting
+
+# Copilot CLI
+~/.copilot/skills/greeting → <source>/skills/greeting
 ```
 
 The agent sees the full directory contents through the symlink.
 
 ## Scope rules
 
-| Scope | Target path |
-|-------|-------------|
-| Global | `~/.claude/skills/<name>` |
-| Project | `.claude/skills/<name>` |
+| Scope | Claude Code | Copilot CLI |
+|-------|-------------|-------------|
+| Global | `~/.claude/skills/<name>` | `~/.copilot/skills/<name>` |
+| Project | `.claude/skills/<name>` | `.github/skills/<name>` |
 
 To undeploy a skill, run [`nd remove`](../../reference/nd_remove.md) `skills/greeting`.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -43,11 +43,11 @@ nd stores all data under `~/.config/nd/`:
 ## Full annotated example
 
 ```yaml
-# Schema version (always 1)
+# Config schema version (always 1)
 version: 1
 
 # Default deployment scope: "global" or "project"
-# Global deploys to ~/.claude/, project deploys to .claude/
+# Default Claude Code paths: global deploys to ~/.claude/, project deploys to .claude/
 default_scope: global
 
 # Default coding agent to target
@@ -74,12 +74,18 @@ sources:
 # context_types: ["CLAUDE.md", "AGENTS.md"]
 
 # Agent configuration overrides (optional)
-# Only needed if your agent uses non-standard directories
+# nd ships with built-in defaults for Claude Code and Copilot CLI.
+# Only needed if your agent uses non-standard directories.
 agents:
   - name: claude-code
     global_dir: ~/.claude
     project_dir: .claude
+  - name: copilot
+    global_dir: ~/.copilot
+    project_dir: .github
 ```
+
+nd includes two built-in agents: Claude Code (default) and Copilot CLI. The `agents` array is for overriding their default directories, not for registering new agents.
 
 ## Config key reference
 
@@ -100,6 +106,7 @@ agents:
 | `agents[].name` | string | -- | Agent name |
 | `agents[].global_dir` | string | -- | Agent's global config directory |
 | `agents[].project_dir` | string | -- | Agent's project config directory |
+| `agents[].source_alias` | string | -- | Alias for agent-specific source resolution |
 
 ## Config merging
 
@@ -171,6 +178,7 @@ These flags work with every nd command and override config file settings for a s
 | `--verbose` / `-v` | Show detailed output on stderr |
 | `--quiet` / `-q` | Suppress non-error output |
 | `--scope` / `-s` | Set deployment scope: `global` or `project` |
+| `--agent` | Target a specific agent (e.g., `claude-code`, `copilot`) |
 | `--config` | Override config file path |
 | `--no-color` | Disable colored output |
 

--- a/docs/guide/creating-sources.md
+++ b/docs/guide/creating-sources.md
@@ -61,11 +61,22 @@ Not every directory needs to be present. nd only discovers assets in directories
 
 ## Context files
 
-Context files have special deployment rules:
+Context files have special deployment rules. The target path depends on which agent is targeted:
 
-- **Global scope:** Deployed to the agent's global directory (e.g., `~/.claude/CLAUDE.md`)
+**Claude Code (default):**
+
+- **Global scope:** Deployed to `~/.claude/CLAUDE.md`
 - **Project scope:** Deployed to the project root directly (e.g., `./CLAUDE.md`), not inside `.claude/`
+
+**Copilot CLI:**
+
+- **Global scope:** Deployed to `~/.copilot/copilot-instructions.md`
+- **Project scope:** Deployed inside the project agent directory (e.g., `.github/copilot-instructions.md`)
+
+**Both agents:**
+
 - **Local files** (`*.local.md`): Deploy only at project scope
+- **Renaming:** When deploying to Copilot CLI, nd automatically renames context files to `copilot-instructions.md` if the source file uses a different name (e.g., `CLAUDE.md`). The source directory always uses `CLAUDE.md` by convention; the deployed filename is determined by the target agent.
 
 ### _meta.yaml
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -59,7 +59,7 @@ Create the nd configuration directory and default config:
 nd init
 ```
 
-This creates `~/.config/nd/config.yaml` with sensible defaults and sets up directories for profiles, snapshots, and state. nd also detects all installed coding agents (Claude Code, Copilot CLI, and others) and selects a default agent to deploy to.
+This creates `~/.config/nd/config.yaml` with sensible defaults and sets up directories for profiles, snapshots, and state. nd also detects installed coding agents (Claude Code and Copilot CLI) and selects a default agent to deploy to.
 
 [`nd init`](../reference/nd_init.md) then prompts you to deploy nd's built-in assets (skills, commands, and an agent) to the detected default agent. Answer **y** to deploy them immediately so you have something to work with, or **n** to skip — you can deploy them later with [`nd deploy`](../reference/nd_deploy.md) `--source builtin`. Pass `--yes` to skip the prompt entirely and deploy automatically.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -59,11 +59,11 @@ Create the nd configuration directory and default config:
 nd init
 ```
 
-This creates `~/.config/nd/config.yaml` with sensible defaults and sets up directories for profiles, snapshots, and state.
+This creates `~/.config/nd/config.yaml` with sensible defaults and sets up directories for profiles, snapshots, and state. nd also detects all installed coding agents (Claude Code, Copilot CLI, and others) and selects a default agent to deploy to.
 
-[`nd init`](../reference/nd_init.md) then prompts you to deploy nd's built-in assets (skills, commands, and an agent). Answer **y** to deploy them immediately so you have something to work with, or **n** to skip — you can deploy them later with [`nd deploy`](../reference/nd_deploy.md) `--source builtin`. Pass `--yes` to skip the prompt entirely and deploy automatically.
+[`nd init`](../reference/nd_init.md) then prompts you to deploy nd's built-in assets (skills, commands, and an agent) to the detected default agent. Answer **y** to deploy them immediately so you have something to work with, or **n** to skip — you can deploy them later with [`nd deploy`](../reference/nd_deploy.md) `--source builtin`. Pass `--yes` to skip the prompt entirely and deploy automatically.
 
-If nd cannot detect your coding agent (e.g., Claude Code is not installed or not in `$PATH`), it skips the built-in deploy with a warning and continues. Install your agent and run `nd deploy --source builtin` afterward.
+If nd cannot detect any coding agent (e.g., none are installed or not in `$PATH`), it skips the built-in deploy with a warning and continues. Install an agent and run `nd deploy --source builtin` afterward.
 
 If a config file already exists, `nd init` exits with an error. Use [`nd settings edit`](../reference/nd_settings_edit.md) to modify an existing configuration.
 
@@ -122,7 +122,7 @@ nd deploy skills/greeting commands/hello agents/researcher
 
 Or run `nd deploy` with no arguments to get an interactive picker. Many nd commands support this interactive mode — [`nd remove`](../reference/nd_remove.md), [`nd profile switch`](../reference/nd_profile_switch.md), [`nd snapshot restore`](../reference/nd_snapshot_restore.md), and others present a picker when run without arguments. nd disables interactive mode in non-TTY environments (pipes, scripts) and when `--json` is set.
 
-nd creates a symlink from your agent's config directory (`~/.claude/skills/greeting`) back to the source. The source stays where it is: edit it and the change shows up immediately. See [How nd works](how-nd-works.md) for the full picture of what happens on disk.
+nd creates a symlink from your agent's config directory (e.g., `~/.claude/skills/greeting` for Claude Code) back to the source. The source stays where it is: edit it and the change shows up immediately. See [How nd works](how-nd-works.md) for the full picture of what happens on disk.
 
 **Deploy by type:**
 
@@ -132,12 +132,22 @@ nd deploy --type skills greeting
 
 **Scopes:**
 
-- **Global** (`--scope global`, default): Deploys to your agent's global config directory (`~/.claude/`)
-- **Project** (`--scope project`): Deploys to the project-level config directory (`.claude/` in the project root)
+- **Global** (`--scope global`, default): Deploys to your agent's global config directory (e.g., `~/.claude/` for Claude Code, `~/.copilot/` for Copilot CLI)
+- **Project** (`--scope project`): Deploys to the project-level config directory (e.g., `.claude/` for Claude Code, `.github/` for Copilot CLI)
 
 ```shell
 nd deploy skills/greeting --scope project
 ```
+
+**Target a specific agent:**
+
+If you have multiple agents installed, nd deploys to the default agent. Use `--agent` to target a different one:
+
+```shell
+nd deploy skills/greeting --agent copilot
+```
+
+Note that not all agents support every asset type. Copilot CLI supports skills, agents, and context only.
 
 **Symlink strategy:**
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -24,7 +24,7 @@ Choose your preferred method:
 
 ```shell
 # Homebrew (macOS/Linux)
-brew install --cask armstrongl/tap/nd
+brew install armstrongl/tap/nd
 
 # Go install
 go install github.com/armstrongl/nd@latest

--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -31,7 +31,12 @@ See [Create asset sources](creating-sources.md) for the full directory layout.
 
 ## Agent config directory
 
-The directory where a coding agent reads its configuration. For Claude Code, this is `~/.claude/` (global) or `.claude/` (project). nd creates symlinks inside this directory when you deploy assets.
+The directory where a coding agent reads its configuration. nd creates symlinks inside this directory when you deploy assets.
+
+| Agent | Global directory | Project directory |
+|---|---|---|
+| Claude Code | `~/.claude/` | `.claude/` |
+| Copilot CLI | `~/.copilot/` | `.github/` |
 
 Configure custom agent directories in your [config file](configuration.md) using the `agents[]` array.
 
@@ -47,7 +52,7 @@ A source embedded inside the nd binary. The builtin source ships nd-specific ass
 
 ## Coding agent
 
-An AI-powered development tool that reads assets from a config directory. Claude Code is the default coding agent. nd also supports other agents (Cursor, Windsurf, Copilot) through the `agents[]` config array.
+An AI-powered development tool that reads assets from a config directory. nd natively supports two built-in agents: Claude Code (default) and Copilot CLI. Additional agents (Cursor, Windsurf, and others) can be configured via the `agents[]` config array.
 
 Not to be confused with [agent (asset type)](#agent-asset-type), which is a file you deploy *to* a coding agent.
 
@@ -55,14 +60,14 @@ Not to be confused with [agent (asset type)](#agent-asset-type), which is a file
 
 A deployable asset that defines a custom slash command for a coding agent. Command assets are single Markdown files stored in the `commands/` directory of a source.
 
-In Claude Code, deployed commands become available as `/command-name` in the chat interface.
+In Claude Code, deployed commands become available as `/command-name` in the chat interface. Commands are supported only by Claude Code — Copilot CLI does not use the commands asset type.
 
 ## Context file
 
 A deployable asset that provides instructions or context to a coding agent. Context files have special deployment rules that differ from other asset types:
 
-- **Global scope**: deploys to the agent config directory (for example, `~/.claude/CLAUDE.md`)
-- **Project scope**: deploys to the project root (for example, `./CLAUDE.md`), not inside `.claude/`
+- **Global scope**: deploys to the agent config directory (for example, `~/.claude/CLAUDE.md` for Claude Code, `~/.copilot/copilot-instructions.md` for Copilot CLI)
+- **Project scope**: deploys to the project root for Claude Code (for example, `./CLAUDE.md`), or inside the agent's project directory for Copilot CLI (for example, `.github/copilot-instructions.md`)
 - **Local files** (`*.local.md`): deploy only at project scope
 
 Context files use a folder-per-asset layout with an optional `_meta.yaml` sidecar for metadata.
@@ -206,10 +211,10 @@ The coding agent auto-loads rules from its config directory. Deployment requires
 
 Where nd deploys an asset. nd supports two scopes:
 
-| Scope | Target directory | Use case |
-|---|---|---|
-| `global` (default) | Agent config directory (`~/.claude/`) | Assets you want in every project |
-| `project` | Project config directory (`.claude/`) | Assets specific to one project |
+| Scope | Claude Code directory | Copilot CLI directory | Use case |
+|---|---|---|---|
+| `global` (default) | `~/.claude/` | `~/.copilot/` | Assets you want in every project |
+| `project` | `.claude/` | `.github/` | Assets specific to one project |
 
 ```shell
 nd deploy skills/greeting              # Global (default)
@@ -222,7 +227,7 @@ See [How nd works](how-nd-works.md#global-vs-project-scope) for details.
 
 A deployable asset that teaches a coding agent a reusable workflow or capability. Skill assets are directories containing a required `SKILL.md` entry-point file and optional supporting files, stored in the `skills/` directory of a source.
 
-Skills are specific to Claude Code. Other coding agents use different terminology for similar concepts (tools, instructions, prompts).
+Skills are supported by Claude Code and Copilot CLI. Other coding agents may use different terminology for similar concepts (tools, instructions, prompts).
 
 ```text
 my-source/
@@ -272,9 +277,11 @@ nd sync --dry-run              # Preview repairs without applying
 
 How nd constructs the symlink path when deploying. nd supports two strategies:
 
-| Strategy | Example | Use case |
+| Strategy | Example (Claude Code) | Use case |
 |---|---|---|
 | `absolute` (default) | `~/.claude/skills/greeting -> /Users/you/my-assets/skills/greeting` | Readable paths for debugging |
 | `relative` | `~/.claude/skills/greeting -> ../../my-assets/skills/greeting` | Portable across machines with different home directory paths |
+
+Paths vary by agent. The examples above show Claude Code; Copilot CLI uses `~/.copilot/` instead.
 
 Set the default in your config file with `symlink_strategy: relative` or per-deploy with `--relative`.

--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -52,7 +52,7 @@ A source embedded inside the nd binary. The builtin source ships nd-specific ass
 
 ## Coding agent
 
-An AI-powered development tool that reads assets from a config directory. nd natively supports two built-in agents: Claude Code (default) and Copilot CLI. Additional agents (Cursor, Windsurf, and others) can be configured via the `agents[]` config array.
+An AI-powered development tool that reads assets from a config directory. nd natively supports two built-in agents: Claude Code (default) and Copilot CLI. The `agents[]` config array can override settings for these built-in agents but does not currently support adding new ones.
 
 Not to be confused with [agent (asset type)](#agent-asset-type), which is a file you deploy *to* a coding agent.
 

--- a/docs/guide/how-nd-works.md
+++ b/docs/guide/how-nd-works.md
@@ -18,7 +18,7 @@ nd doesn't copy files. It creates symlinks.
 
 When you run [`nd deploy`](../reference/nd_deploy.md) `skills/greeting`, nd creates a symlink from your agent's config directory back to the original source. The source stays where it is. Edit the source, and the change shows up instantly in the deployed location: no redeploy needed.
 
-nd supports multiple agents. By default it targets **Claude Code**, but you can target **Copilot CLI** with the `--agent copilot` flag on any command. Each agent has its own config directories, supported asset types, and context file conventions.
+nd supports multiple agents. When no `--agent` flag is provided, nd targets the configured default agent if detected, falling back to the first detected agent. You can target a specific agent with the `--agent` flag on any command (e.g., `--agent copilot`). Each agent has its own config directories, supported asset types, and context file conventions.
 
 ## The mental model
 

--- a/docs/guide/how-nd-works.md
+++ b/docs/guide/how-nd-works.md
@@ -18,21 +18,24 @@ nd doesn't copy files. It creates symlinks.
 
 When you run [`nd deploy`](../reference/nd_deploy.md) `skills/greeting`, nd creates a symlink from your agent's config directory back to the original source. The source stays where it is. Edit the source, and the change shows up instantly in the deployed location: no redeploy needed.
 
+nd supports multiple agents. By default it targets **Claude Code**, but you can target **Copilot CLI** with the `--agent copilot` flag on any command. Each agent has its own config directories, supported asset types, and context file conventions.
+
 ## The mental model
 
-nd wires each deployed asset from your source into the agent's config directory:
+nd wires each deployed asset from your source into the target agent's config directory:
 
 ```text
   your source               nd               agent config dir
-┌────────────────┐     (creates link)     ┌──────────────────┐
-│ ~/my-assets/   │  ─── nd deploy ───▶    │ ~/.claude/        │
-│   skills/      │                        │   skills/         │
-│   rules/       │                        │   rules/          │
-│   agents/      │                        │   agents/         │
+┌────────────────┐                        ┌──────────────────┐
+│ ~/my-assets/   │  ─── nd deploy ───▶    │ Claude Code:     │
+│   skills/      │                        │   ~/.claude/     │
+│   rules/       │                        ├──────────────────┤
+│   agents/      │  ─── nd deploy ───▶    │ Copilot CLI:     │
+│   context/     │      --agent copilot   │   ~/.copilot/    │
 └────────────────┘                        └──────────────────┘
 ```
 
-Your files stay in the source. nd creates links so the agent can find them. You manage the source; nd manages the wiring.
+The same source can serve multiple agents. nd creates links into whichever agent you target. You manage the source; nd manages the wiring.
 
 ## What deploys look like
 
@@ -50,14 +53,16 @@ Here is a source directory with two assets: a skill (directory) and a rule (file
 After running `nd deploy skills/greeting rules/no-emojis`, your agent's config directory looks like this:
 
 ```text
-~/.claude/
+~/.claude/                                              # Claude Code (default)
 ├── skills/
-│   └── greeting -> ~/my-assets/skills/greeting   # directory symlink
+│   └── greeting -> ~/my-assets/skills/greeting         # directory symlink
 └── rules/
-    └── no-emojis.md -> ~/my-assets/rules/no-emojis.md   # file symlink
+    └── no-emojis.md -> ~/my-assets/rules/no-emojis.md  # file symlink
 ```
 
-nd creates the parent directories (`~/.claude/skills/`, `~/.claude/rules/`) if they don't already exist.
+The target directory depends on the agent. For Copilot CLI, assets deploy into `~/.copilot/` instead. Pass `--agent copilot` to target Copilot.
+
+nd creates the parent directories (for example, `~/.claude/skills/`) if they don't already exist.
 
 The `->` arrow shows where the symlink points. `greeting` is a directory symlink (the whole skill folder), while `no-emojis.md` is a file symlink. Both point back to the original source.
 
@@ -70,18 +75,31 @@ ls -la ~/.claude/skills/
 
 ## Global vs project scope
 
-nd deploys to one of two places depending on the scope:
+nd deploys to one of two places depending on the scope. The exact directories depend on which agent you target:
 
-**Global scope** (default) deploys to your agent's user-wide config directory:
+| Agent | Global directory | Project directory |
+|---|---|---|
+| Claude Code (default) | `~/.claude/` | `<project>/.claude/` |
+| Copilot CLI | `~/.copilot/` | `<project>/.github/` |
+
+**Global scope** (default) deploys to the agent's user-wide config directory:
 
 ```text
+# Claude Code
 ~/.claude/skills/greeting -> ~/my-assets/skills/greeting
+
+# Copilot CLI
+~/.copilot/skills/greeting -> ~/my-assets/skills/greeting
 ```
 
 **Project scope** deploys to the current project's config directory:
 
 ```text
+# Claude Code
 ~/myproject/.claude/skills/greeting -> ~/my-assets/skills/greeting
+
+# Copilot CLI
+~/myproject/.github/skills/greeting -> ~/my-assets/skills/greeting
 ```
 
 Use global scope for assets you want everywhere. Use project scope for assets that only make sense in a specific repo.
@@ -92,13 +110,20 @@ nd deploy skills/greeting
 
 # Project
 nd deploy skills/greeting --scope project
+
+# Target a specific agent
+nd deploy skills/greeting --agent copilot
 ```
 
 See the [configuration guide](configuration.md) for how to change the default scope.
 
 ## Context files (the exception)
 
-Context files break the pattern. Every other asset type deploys into a subdirectory (`skills/`, `rules/`, `agents/`, and others). Context files deploy directly into the config directory or project root.
+Context files break the pattern. Every other asset type deploys into a subdirectory (`skills/`, `rules/`, `agents/`, and others). Context files deploy directly into the config directory or project root, and each agent expects a different filename.
+
+### Claude Code
+
+Claude Code reads context from a file named `CLAUDE.md`.
 
 **Global scope:** deploys into the agent's config directory:
 
@@ -113,6 +138,30 @@ Context files break the pattern. Every other asset type deploys into a subdirect
 ```
 
 This is intentional. Claude Code reads project-level context from the project root (`./CLAUDE.md`), not from `.claude/CLAUDE.md`.
+
+### Copilot CLI
+
+Copilot CLI reads context from a file named `copilot-instructions.md`.
+
+**Global scope:** deploys into the agent's config directory:
+
+```text
+~/.copilot/copilot-instructions.md -> ~/my-assets/context/go-project-rules/CLAUDE.md
+```
+
+**Project scope:** deploys into the project directory, NOT the project root:
+
+```text
+~/myproject/.github/copilot-instructions.md -> ~/my-assets/context/go-project-rules/CLAUDE.md
+```
+
+Note the difference from Claude Code: Copilot context goes inside `.github/`, not at the project root.
+
+### Automatic context file renaming
+
+When a context source has a filename that doesn't match the target agent's expected name, nd renames the deployed symlink automatically. For example, deploying a `CLAUDE.md` source to Copilot CLI creates a link named `copilot-instructions.md`. This means a single context source can serve both agents without manual renaming.
+
+### Context rules
 
 Two things to keep in mind:
 
@@ -147,9 +196,23 @@ nd deploy skills/greeting --relative
 
 ## What the agent sees
 
-Once you deploy an asset, Claude Code uses it. Claude Code typically loads skills, agents, commands, and rules from `~/.claude/` at session start. It loads project-scope assets when you run it from that project's directory.
+Once you deploy an asset, the target agent typically picks it up. Each agent loads assets from its own config directory at session start, and project-scope assets when you run it from that project's directory.
 
-Two asset types need an extra step after deploying:
+Not all agents support all asset types:
+
+| Asset type | Claude Code | Copilot CLI |
+|---|---|---|
+| skills | ✓ | ✓ |
+| agents | ✓ | ✓ |
+| context | ✓ | ✓ |
+| commands | ✓ | — |
+| output-styles | ✓ | — |
+| rules | ✓ | — |
+| hooks | ✓ | — |
+
+nd prevents you from deploying unsupported types to an agent.
+
+For Claude Code, two asset types need an extra step after deploying:
 
 - **Hooks** and **output-styles** require manual registration in Claude Code's `settings.json`. nd creates the symlink, but Claude Code needs to be told about them in its settings file. Check Claude Code's documentation for the specific settings entries.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -148,7 +148,7 @@ The `nd status` output shows the origin of each asset: `manual`, `pinned`, or th
 
 **Symptoms:** Deploying a context file reports that a backup was created.
 
-**Explanation:** Only one context file can occupy each target location (e.g., `~/.claude/CLAUDE.md`). When you deploy a second context file to the same path, nd backs up the existing one to `~/.config/nd/backups/` before replacing it.
+**Explanation:** Only one context file can occupy each target location (e.g., `~/.claude/CLAUDE.md` for Claude Code, or `~/.copilot/copilot-instructions.md` for Copilot CLI). When you deploy a second context file to the same path, nd backs up the existing one to `~/.config/nd/backups/` before replacing it.
 
 **Fix:**
 
@@ -176,9 +176,10 @@ See [Context files](asset-types/context.md) for the special scoping rules that d
 
 ```shell
 # Check if the agent binary exists
-which claude
+which claude        # Claude Code
+which copilot-cli   # Copilot CLI
 
-# Create the global config directory if needed
+# Create the global config directory if needed (Claude Code shown; Copilot CLI uses ~/.copilot/)
 mkdir -p ~/.claude
 
 # Verify agent configuration
@@ -245,16 +246,29 @@ Or switch to a profile first with [`nd profile switch`](../reference/nd_profile_
 
 **Symptoms:** `nd deploy` fails with `conflict at <path>: existing <kind> blocks deployment of <asset>`.
 
-**Cause:** A file or symlink that nd does not manage already exists at the target location. This happens when you have manually created a file where nd wants to place a symlink (e.g., a hand-written `CLAUDE.md` at `~/.claude/CLAUDE.md`).
+**Cause:** A file or symlink that nd does not manage already exists at the target location. This happens when you have manually created a file where nd wants to place a symlink (e.g., a hand-written `CLAUDE.md` at `~/.claude/CLAUDE.md`, or `copilot-instructions.md` at `~/.copilot/copilot-instructions.md` for Copilot CLI).
 
 **Fix:** Move or remove the conflicting file, then retry the deploy:
 
 ```shell
+# Claude Code example (Copilot CLI equivalent: ~/.copilot/copilot-instructions.md)
 mv ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.bak
 nd deploy context/my-rules
 ```
 
 For context files specifically, nd automatically backs up the existing file to `~/.config/nd/backups/` and replaces it. Conflicts only block deployment for non-context asset types.
+
+## Copilot CLI path differences
+
+nd supports multiple agents, each with its own directory layout. If you switched from Claude Code to Copilot CLI (or use both), note these differences:
+
+| | Claude Code | Copilot CLI |
+|---|---|---|
+| Global config directory | `~/.claude/` | `~/.copilot/` |
+| Project config directory | `.claude/` | `.github/` |
+| Context file name | `CLAUDE.md` | `copilot-instructions.md` |
+
+Most troubleshooting steps in this guide show Claude Code paths. Substitute the Copilot CLI equivalents when debugging Copilot deployments. Use `nd doctor` to confirm which agents nd detects and where it expects their directories.
 
 ## Git not found
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -177,7 +177,7 @@ See [Context files](asset-types/context.md) for the special scoping rules that d
 ```shell
 # Check if the agent binary exists
 which claude        # Claude Code
-which copilot-cli   # Copilot CLI
+which copilot       # Copilot CLI
 
 # Create the global config directory if needed (Claude Code shown; Copilot CLI uses ~/.copilot/)
 mkdir -p ~/.claude

--- a/docs/guide/user-guide.md
+++ b/docs/guide/user-guide.md
@@ -150,7 +150,7 @@ Use `--agent` to deploy to a particular agent:
 nd deploy skills/greeting --agent copilot
 ```
 
-When no `--agent` flag is provided, nd deploys to the default agent (Claude Code).
+When no `--agent` flag is provided, nd deploys to the configured default agent if it is detected. Otherwise, nd falls back to the first detected agent.
 
 > **Note:** Not all agents support all asset types. Copilot CLI supports only skills, agents, and context. Attempting to deploy an unsupported type (such as commands or output-styles) to an incompatible agent produces an error.
 

--- a/docs/guide/user-guide.md
+++ b/docs/guide/user-guide.md
@@ -38,6 +38,7 @@ These flags work with every command:
 | `--quiet` / `-q` | Suppress non-error output |
 | `--scope` / `-s` | Set deployment scope: `global` or `project` |
 | `--config` | Override config file path |
+| `--agent` | Target a specific agent (e.g., `claude-code`, `copilot`) |
 | `--no-color` | Disable colored output |
 
 Example scripted workflow:
@@ -134,12 +135,24 @@ Bulk operations continue on per-asset failure and report a summary.
 
 ### Scopes
 
-- **Global** (`--scope global`, default): Deploys to your agent's global config directory (`~/.claude/`)
-- **Project** (`--scope project`): Deploys to the project-level config directory (`.claude/` in project root)
+- **Global** (`--scope global`, default): Deploys to your agent's global config directory (`~/.claude/` for Claude Code, `~/.copilot/` for Copilot CLI)
+- **Project** (`--scope project`): Deploys to the project-level config directory (`.claude/` for Claude Code, `.github/` for Copilot CLI)
 
 ```shell
 nd deploy skills/greeting --scope project
 ```
+
+### Target a specific agent
+
+Use `--agent` to deploy to a particular agent:
+
+```shell
+nd deploy skills/greeting --agent copilot
+```
+
+When no `--agent` flag is provided, nd deploys to the default agent (Claude Code).
+
+> **Note:** Not all agents support all asset types. Copilot CLI supports only skills, agents, and context. Attempting to deploy an unsupported type (such as commands or output-styles) to an incompatible agent produces an error.
 
 ### Symlink strategy
 

--- a/docs/reference/nd.md
+++ b/docs/reference/nd.md
@@ -33,6 +33,7 @@ nd [flags]
 ## Options
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
   -h, --help            help for nd

--- a/docs/reference/nd_completion.md
+++ b/docs/reference/nd_completion.md
@@ -31,6 +31,7 @@ Run "nd completion <shell> --help" for shell-specific instructions.
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_completion_bash.md
+++ b/docs/reference/nd_completion_bash.md
@@ -43,6 +43,7 @@ nd completion bash [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_completion_fish.md
+++ b/docs/reference/nd_completion_fish.md
@@ -41,6 +41,7 @@ nd completion fish [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_completion_zsh.md
+++ b/docs/reference/nd_completion_zsh.md
@@ -48,6 +48,7 @@ nd completion zsh [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_deploy.md
+++ b/docs/reference/nd_deploy.md
@@ -55,6 +55,7 @@ nd deploy <asset> [assets...] [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_doctor.md
+++ b/docs/reference/nd_doctor.md
@@ -29,6 +29,7 @@ nd doctor [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_export.md
+++ b/docs/reference/nd_export.md
@@ -46,6 +46,7 @@ nd export [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_export_marketplace.md
+++ b/docs/reference/nd_export_marketplace.md
@@ -39,6 +39,7 @@ nd export marketplace [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_init.md
+++ b/docs/reference/nd_init.md
@@ -37,6 +37,7 @@ nd init [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_list.md
+++ b/docs/reference/nd_list.md
@@ -41,6 +41,7 @@ nd list [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_pin.md
+++ b/docs/reference/nd_pin.md
@@ -29,6 +29,7 @@ nd pin <asset> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile.md
+++ b/docs/reference/nd_profile.md
@@ -27,6 +27,7 @@ Create, list, deploy, and switch between named profiles.
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile_add-asset.md
+++ b/docs/reference/nd_profile_add-asset.md
@@ -29,6 +29,7 @@ nd profile add-asset <profile> <asset> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile_create.md
+++ b/docs/reference/nd_profile_create.md
@@ -32,6 +32,7 @@ nd profile create <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile_delete.md
+++ b/docs/reference/nd_profile_delete.md
@@ -29,6 +29,7 @@ nd profile delete <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile_deploy.md
+++ b/docs/reference/nd_profile_deploy.md
@@ -29,6 +29,7 @@ nd profile deploy <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile_list.md
+++ b/docs/reference/nd_profile_list.md
@@ -29,6 +29,7 @@ nd profile list [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_profile_switch.md
+++ b/docs/reference/nd_profile_switch.md
@@ -29,6 +29,7 @@ nd profile switch <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_remove.md
+++ b/docs/reference/nd_remove.md
@@ -35,6 +35,7 @@ nd remove <asset> [assets...] [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_settings.md
+++ b/docs/reference/nd_settings.md
@@ -21,6 +21,7 @@ Manage nd settings
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_settings_edit.md
+++ b/docs/reference/nd_settings_edit.md
@@ -26,6 +26,7 @@ nd settings edit [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_snapshot.md
+++ b/docs/reference/nd_snapshot.md
@@ -27,6 +27,7 @@ Save, restore, list, and delete point-in-time deployment snapshots.
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_snapshot_delete.md
+++ b/docs/reference/nd_snapshot_delete.md
@@ -29,6 +29,7 @@ nd snapshot delete <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_snapshot_list.md
+++ b/docs/reference/nd_snapshot_list.md
@@ -29,6 +29,7 @@ nd snapshot list [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_snapshot_restore.md
+++ b/docs/reference/nd_snapshot_restore.md
@@ -29,6 +29,7 @@ nd snapshot restore <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_snapshot_save.md
+++ b/docs/reference/nd_snapshot_save.md
@@ -26,6 +26,7 @@ nd snapshot save <name> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_source.md
+++ b/docs/reference/nd_source.md
@@ -27,6 +27,7 @@ Add, remove, and list asset source directories.
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_source_add.md
+++ b/docs/reference/nd_source_add.md
@@ -39,6 +39,7 @@ nd source add <path|url> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_source_list.md
+++ b/docs/reference/nd_source_list.md
@@ -29,6 +29,7 @@ nd source list [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_source_remove.md
+++ b/docs/reference/nd_source_remove.md
@@ -29,6 +29,7 @@ nd source remove <source-id> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_status.md
+++ b/docs/reference/nd_status.md
@@ -32,6 +32,7 @@ nd status [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_sync.md
+++ b/docs/reference/nd_sync.md
@@ -33,6 +33,7 @@ nd sync [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_uninstall.md
+++ b/docs/reference/nd_uninstall.md
@@ -29,6 +29,7 @@ nd uninstall [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_unpin.md
+++ b/docs/reference/nd_unpin.md
@@ -26,6 +26,7 @@ nd unpin <asset> [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/docs/reference/nd_version.md
+++ b/docs/reference/nd_version.md
@@ -25,6 +25,7 @@ nd version [flags]
 ## Options inherited from parent commands
 
 ```
+      --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes
       --json            output in JSON format

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -16,7 +16,7 @@ title: nd
 {{< /hextra/hero-subtitle >}}
 
 ```shell
-brew install --cask armstrongl/tap/nd
+brew install armstrongl/tap/nd
 ```
 
 {{< hextra/hero-button text="Get started" link="docs/guide/getting-started/" >}}

--- a/site/content/docs/about.md
+++ b/site/content/docs/about.md
@@ -20,7 +20,7 @@ nd creates symlinks from your agent's config directory to asset sources (local d
 
 ```shell
 # Homebrew (macOS/Linux)
-brew install --cask armstrongl/tap/nd
+brew install armstrongl/tap/nd
 
 # Go install
 go install github.com/armstrongl/nd@latest


### PR DESCRIPTION
## Summary

Comprehensive documentation audit and update to reflect the multi-agent support added in #92. The docs previously described nd as a Claude Code-only tool — this PR updates all 52 affected files.

## Changes

### Guide docs (14 files)
- **how-nd-works**: Multi-agent diagrams, per-agent context behavior, asset type support matrix
- **getting-started**: Agent detection during init, `--agent` flag, agent-aware scope paths
- **configuration**: `--agent` global flag, `agents[].source_alias` field, copilot override example, built-in agents note
- **user-guide**: `--agent` flag, agent compatibility note, scope path examples
- **glossary**: Updated coding agent, config directory, context, scope, skill entries
- **troubleshooting**: Copilot path differences section, agent-aware examples
- **asset types**: Skills/agents updated with Copilot paths; commands/rules/hooks/output-styles marked Claude Code-only; context doc overhauled with per-agent behavior and automatic renaming
- **creating-sources**: Multi-agent context section with renaming behavior

### Root docs (2 files)
- **ARCHITECTURE.md**: Added updater/builtin packages, multi-agent registry, schema v2 migration, fixed all `--` list separators to `:`
- **README.md**: Multi-agent support bullet, `--agent` flag, copilot agent mention

### Reference docs (36 files)
- Regenerated via `gendocs` to pick up the new `--agent` global flag

## Validation
- `scripts/lint-docs.sh`: 0 errors (6 pre-existing warnings)
- `go build`: passes
- Code review agent caught and fixed 3 issues (incorrect Copilot context path in glossary, wrong agent names in user-guide and README)

## Key facts documented
| Agent | Global dir | Project dir | Supported types | Context file |
|-------|-----------|-------------|-----------------|-------------|
| Claude Code (default) | `~/.claude/` | `.claude/` | All deployable | `CLAUDE.md` |
| Copilot CLI | `~/.copilot/` | `.github/` | skills, agents, context | `copilot-instructions.md` |
