### PR TITLE
docs(reference): add enhanced code blocks to CLI reference pages

### DIFF
--- a/docs/guide/asset-types/agents.md
+++ b/docs/guide/asset-types/agents.md
@@ -21,7 +21,7 @@ Agents are single-file assets that define the behavior, persona, or instructions
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 agents/
 ├── researcher.md
 └── code-reviewer.md
@@ -35,7 +35,7 @@ Each agent is a markdown file containing agent instructions, a system prompt, or
 
 nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `agents/researcher` produces a symlink in the active agent's config directory:
 
-```text
+```text {filename="Deployment paths"}
 # Claude Code
 ~/.claude/agents/researcher.md → <source>/agents/researcher.md
 
@@ -61,7 +61,7 @@ To undeploy an agent, run [`nd remove`](../../reference/nd_remove.md) `agents/re
 
 ## Create an agent
 
-```shell
+```shell {filename="Terminal"}
 cat > ~/my-assets/agents/researcher.md << 'EOF'
 # Researcher agent
 

--- a/docs/guide/asset-types/commands.md
+++ b/docs/guide/asset-types/commands.md
@@ -21,7 +21,7 @@ Commands are single-file assets that define custom slash commands available to c
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 commands/
 ├── deploy-all.md
 └── review-pr.md
@@ -35,7 +35,7 @@ Each command is a markdown file whose base filename becomes the slash command na
 
 nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `commands/deploy-all` produces:
 
-```text
+```text {filename="Deployment paths"}
 ~/.claude/commands/deploy-all.md → <source>/commands/deploy-all.md
 ```
 
@@ -57,7 +57,7 @@ To undeploy a command, run [`nd remove`](../../reference/nd_remove.md) `commands
 
 ## Create a command
 
-```shell
+```shell {filename="Terminal"}
 cat > ~/my-assets/commands/deploy-all.md << 'EOF'
 Deploy all available assets from all sources using nd deploy.
 List assets first with nd list, then deploy each one.

--- a/docs/guide/asset-types/context.md
+++ b/docs/guide/asset-types/context.md
@@ -23,7 +23,7 @@ Context assets provide persistent instructions or project conventions to coding 
 
 Each context asset is a directory containing a context file and an optional `_meta.yaml` sidecar.
 
-```text
+```text {filename="Source layout"}
 context/
 ├── go-project-rules/
 │   ├── CLAUDE.md
@@ -36,7 +36,7 @@ context/
 
 The context file (e.g., `CLAUDE.md` or `copilot-instructions.md`) contains the instructions or conventions in plain Markdown. The optional `_meta.yaml` sidecar carries metadata used by nd for listing and filtering.
 
-```yaml
+```yaml {filename="_meta.yaml"}
 # _meta.yaml
 description: "Project coding standards and conventions"
 tags: ["standards", "conventions"]
@@ -88,7 +88,7 @@ To undeploy a context asset, run [`nd remove`](../../reference/nd_remove.md) `co
 
 ## Create a context asset
 
-```shell
+```shell {filename="Terminal"}
 mkdir -p ~/my-assets/context/go-standards
 
 cat > ~/my-assets/context/go-standards/CLAUDE.md << 'EOF'

--- a/docs/guide/asset-types/hooks.md
+++ b/docs/guide/asset-types/hooks.md
@@ -21,7 +21,7 @@ Hooks are directory assets that define event-driven automation triggered by agen
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 hooks/
 └── pre-tool-lint/
     ├── hooks.json
@@ -32,7 +32,7 @@ hooks/
 
 Each hook is a directory containing a `hooks.json` configuration file and one or more executable scripts.
 
-```json
+```json {filename="hooks.json"}
 {
   "event": "PreToolUse",
   "description": "Run linter before tool use"
@@ -67,7 +67,7 @@ To undeploy a hook, run [`nd remove`](../../reference/nd_remove.md) `hooks/lint-
 
 ## Create a hook
 
-```shell
+```shell {filename="Terminal"}
 mkdir -p ~/my-assets/hooks/lint-check
 
 cat > ~/my-assets/hooks/lint-check/hooks.json << 'EOF'

--- a/docs/guide/asset-types/output-styles.md
+++ b/docs/guide/asset-types/output-styles.md
@@ -21,7 +21,7 @@ Output styles are single-file assets that define formatting instructions for age
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 output-styles/
 ├── concise.md
 └── learning.md
@@ -31,7 +31,7 @@ output-styles/
 
 Each output style is a plain Markdown file describing the formatting behavior the agent should apply when the style is active. There is no required frontmatter.
 
-```markdown
+```markdown {filename="Markdown"}
 Respond with minimal text. Use bullet points. No explanations unless asked.
 Maximum 3 sentences per response.
 ```
@@ -62,7 +62,7 @@ To undeploy an output style, run [`nd remove`](../../reference/nd_remove.md) `ou
 
 ## Create an output style
 
-```shell
+```shell {filename="Terminal"}
 mkdir -p ~/my-assets/output-styles
 
 cat > ~/my-assets/output-styles/concise.md << 'EOF'

--- a/docs/guide/asset-types/plugins.md
+++ b/docs/guide/asset-types/plugins.md
@@ -20,7 +20,7 @@ Plugins are directory assets that bundle multiple nd assets into a Claude Code p
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 plugins/
 └── my-toolbox/
     ├── .claude-plugin/
@@ -36,7 +36,7 @@ plugins/
 
 A plugin directory contains a `.claude-plugin/` subdirectory with a `plugin.json` manifest inside it, plus asset subdirectories that follow the standard nd structure.
 
-```json
+```json {filename="plugin.json"}
 {
   "name": "my-toolbox",
   "version": "1.0.0",
@@ -50,7 +50,7 @@ Asset subdirectories inside the plugin (e.g., `skills/`, `commands/`) follow the
 
 Plugins are **not deployable via `nd deploy`**. Instead, use [`nd export`](../../reference/nd_export.md) to package the assets you want to include, then install the exported package through your agent's plugin installation mechanism.
 
-```shell
+```shell {filename="Terminal"}
 nd export --assets skills/greeting,commands/hello --output ./my-plugin
 ```
 
@@ -75,7 +75,7 @@ You can also generate a marketplace listing with [`nd export marketplace`](../..
 
 Create the plugin directory structure inside your source. A plugin needs a `.claude-plugin/plugin.json` manifest and at least one nested asset:
 
-```shell
+```shell {filename="Terminal"}
 mkdir -p ~/my-assets/plugins/my-toolbox/.claude-plugin
 mkdir -p ~/my-assets/plugins/my-toolbox/skills/greeting
 

--- a/docs/guide/asset-types/rules.md
+++ b/docs/guide/asset-types/rules.md
@@ -21,7 +21,7 @@ Rules are assets that define behavioral constraints or conventions a coding agen
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 rules/
 ├── no-emojis.md
 ├── always-test.md
@@ -37,7 +37,7 @@ Each rule is a markdown file whose base filename describes the constraint it enc
 
 nd symlinks the individual file into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `rules/no-emojis` produces:
 
-```text
+```text {filename="Deployment paths"}
 ~/.claude/rules/no-emojis.md → <source>/rules/no-emojis.md
 ```
 
@@ -59,7 +59,7 @@ To undeploy a rule, run [`nd remove`](../../reference/nd_remove.md) `rules/no-em
 
 ## Create a rule
 
-```shell
+```shell {filename="Terminal"}
 cat > ~/my-assets/rules/no-emojis.md << 'EOF'
 Never use emojis in code comments, commit messages, or documentation unless the user explicitly requests them.
 EOF

--- a/docs/guide/asset-types/skills.md
+++ b/docs/guide/asset-types/skills.md
@@ -21,7 +21,7 @@ Skills are multi-file directory assets that package reusable coding-agent behavi
 
 ## Directory layout
 
-```text
+```text {filename="Source layout"}
 skills/
 ├── greeting/
 │   └── SKILL.md
@@ -39,7 +39,7 @@ The entry point is a file named `SKILL.md` at the root of the skill directory (e
 
 nd symlinks the entire skill directory into the target location (see [How nd works](../how-nd-works.md) for details on the symlink strategy). Running [`nd deploy`](../../reference/nd_deploy.md) `skills/greeting` produces a symlink in the active agent's config directory:
 
-```text
+```text {filename="Deployment paths"}
 # Claude Code
 ~/.claude/skills/greeting → <source>/skills/greeting
 
@@ -67,7 +67,7 @@ To undeploy a skill, run [`nd remove`](../../reference/nd_remove.md) `skills/gre
 
 ## Create a skill
 
-```shell
+```shell {filename="Terminal"}
 mkdir -p ~/my-assets/skills/greeting
 cat > ~/my-assets/skills/greeting/SKILL.md << 'EOF'
 # Greeting skill

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -42,7 +42,7 @@ nd stores all data under `~/.config/nd/`:
 
 ## Full annotated example
 
-```yaml
+```yaml {filename="config.yaml"}
 # Config schema version (always 1)
 version: 1
 
@@ -123,7 +123,7 @@ For sources, global sources appear first (higher priority), followed by project 
 
 Create `.nd/config.yaml` in your project root to override settings per-project:
 
-```yaml
+```yaml {filename=".nd/config.yaml"}
 version: 1
 default_scope: project
 sources:
@@ -152,13 +152,13 @@ If you have not set `$EDITOR` or `$VISUAL`, `nd settings edit` uses `vi`.
 
 Open your config in your default editor with [`nd settings edit`](../reference/nd_settings_edit.md):
 
-```shell
+```shell {filename="Terminal"}
 nd settings edit
 ```
 
 After editing, validate your config with [`nd doctor`](../reference/nd_doctor.md):
 
-```shell
+```shell {filename="Terminal"}
 nd doctor
 ```
 
@@ -184,7 +184,7 @@ These flags work with every nd command and override config file settings for a s
 
 Example scripted workflow:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --yes --json | jq '.status'
 ```
 
@@ -194,7 +194,7 @@ nd records every mutating operation to a JSONL log file at `~/.config/nd/logs/op
 
 ### View the log
 
-```shell
+```shell {filename="Terminal"}
 # Last 10 operations
 tail -10 ~/.config/nd/logs/operations.log
 

--- a/docs/guide/creating-sources.md
+++ b/docs/guide/creating-sources.md
@@ -19,7 +19,7 @@ An asset source is a directory that organizes coding agent assets by type. nd su
 
 nd discovers assets by looking for directories named after asset types:
 
-```text
+```text {filename="Source layout"}
 my-assets/
 ├── skills/
 │   ├── greeting/           # Directory asset
@@ -82,7 +82,7 @@ Context files have special deployment rules. The target path depends on which ag
 
 Context files can include a `_meta.yaml` sidecar for metadata:
 
-```yaml
+```yaml {filename="_meta.yaml"}
 description: "Project coding standards and conventions"
 tags: ["standards", "conventions"]
 ```
@@ -91,7 +91,7 @@ tags: ["standards", "conventions"]
 
 For sources that don't follow the convention-based directory structure, create an `nd-source.yaml` manifest at the source root:
 
-```yaml
+```yaml {filename="nd-source.yaml"}
 # nd-source.yaml
 version: 1
 paths:
@@ -109,7 +109,7 @@ When an `nd-source.yaml` manifest is present, it **overrides** convention-based 
 
 To share your asset source, push it to git:
 
-```shell
+```shell {filename="Terminal"}
 cd my-assets
 git init
 git add .
@@ -120,7 +120,7 @@ git push -u origin main
 
 Others can add it with [`nd source add`](../reference/nd_source_add.md):
 
-```shell
+```shell {filename="Terminal"}
 nd source add you/my-assets
 # or
 nd source add https://github.com/you/my-assets.git
@@ -132,7 +132,7 @@ nd clones git sources to `~/.config/nd/sources/`. Sync them with [`nd sync`](../
 
 Remove a registered source with [`nd source remove`](../reference/nd_source_remove.md):
 
-```shell
+```shell {filename="Terminal"}
 nd source remove <source-id>
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -22,7 +22,7 @@ This guide takes you from zero to your first deployed asset in about 5 minutes.
 
 Choose your preferred method:
 
-```shell
+```shell {filename="Terminal"}
 # Homebrew (macOS/Linux)
 brew install armstrongl/tap/nd
 
@@ -35,7 +35,7 @@ git clone https://github.com/armstrongl/nd.git && cd nd && go build -o nd .
 
 Verify the installation with [`nd version`](../reference/nd_version.md):
 
-```shell
+```shell {filename="Terminal"}
 nd version
 ```
 
@@ -43,7 +43,7 @@ nd version
 
 If you installed nd via Homebrew, update it with:
 
-```shell
+```shell {filename="Terminal"}
 brew update && brew upgrade nd
 ```
 
@@ -55,7 +55,7 @@ nd also notifies you when a newer version is available — the message appears a
 
 Create the nd configuration directory and default config:
 
-```shell
+```shell {filename="Terminal"}
 nd init
 ```
 
@@ -69,7 +69,7 @@ If a config file already exists, `nd init` exits with an error. Use [`nd setting
 
 Browse the built-in assets with [`nd list`](../reference/nd_list.md):
 
-```shell
+```shell {filename="Terminal"}
 nd list
 ```
 
@@ -77,7 +77,7 @@ nd list
 
 nd ships with a **builtin** source containing nd-specific assets. To add your own assets, register a **source** with [`nd source add`](../reference/nd_source_add.md): a local directory or git repository containing agent assets organized by type.
 
-```shell
+```shell {filename="Terminal"}
 # Local directory
 nd source add ~/my-coding-assets
 
@@ -94,13 +94,13 @@ nd scans the source for assets organized in convention-based directories (`skill
 
 List all assets discovered from your sources:
 
-```shell
+```shell {filename="Terminal"}
 nd list
 ```
 
 Filter by type:
 
-```shell
+```shell {filename="Terminal"}
 nd list --type skills
 ```
 
@@ -110,13 +110,13 @@ Assets marked with `*` are already deployed.
 
 Deploy an asset by creating a symlink in your agent's config directory:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting
 ```
 
 Deploy multiple assets at once:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting commands/hello agents/researcher
 ```
 
@@ -126,7 +126,7 @@ nd creates a symlink from your agent's config directory (e.g., `~/.claude/skills
 
 **Deploy by type:**
 
-```shell
+```shell {filename="Terminal"}
 nd deploy --type skills greeting
 ```
 
@@ -135,7 +135,7 @@ nd deploy --type skills greeting
 - **Global** (`--scope global`, default): Deploys to your agent's global config directory (e.g., `~/.claude/` for Claude Code, `~/.copilot/` for Copilot CLI)
 - **Project** (`--scope project`): Deploys to the project-level config directory (e.g., `.claude/` for Claude Code, `.github/` for Copilot CLI)
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --scope project
 ```
 
@@ -143,7 +143,7 @@ nd deploy skills/greeting --scope project
 
 If you have multiple agents installed, nd deploys to the default agent. Use `--agent` to target a different one:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --agent copilot
 ```
 
@@ -154,7 +154,7 @@ Note that not all agents support every asset type. Copilot CLI supports skills, 
 - **Absolute** (default): Symlinks use absolute paths
 - **Relative** (`--relative`): Symlinks use relative paths (better for portable setups)
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --relative
 ```
 
@@ -164,7 +164,7 @@ Change the default strategy in your config file (`symlink_strategy: relative`).
 
 Check that everything is healthy with [`nd status`](../reference/nd_status.md):
 
-```shell
+```shell {filename="Terminal"}
 nd status
 ```
 
@@ -172,7 +172,7 @@ The output shows your deployed assets with health indicators (checkmarks for hea
 
 For a full health check, run [`nd doctor`](../reference/nd_doctor.md):
 
-```shell
+```shell {filename="Terminal"}
 nd doctor
 ```
 
@@ -182,7 +182,7 @@ nd doctor
 
 Enable tab-completion for your shell with [`nd completion`](../reference/nd_completion.md):
 
-```shell
+```shell {filename="Terminal"}
 # Print completion script
 nd completion bash
 nd completion zsh
@@ -199,7 +199,7 @@ nd completion zsh --install-dir ~/.my-completions
 
 For zsh, add this to your `~/.zshrc` if not already present:
 
-```shell
+```shell {filename="Terminal"}
 fpath+=~/.zfunc
 autoload -Uz compinit && compinit
 ```
@@ -208,7 +208,7 @@ autoload -Uz compinit && compinit
 
 Open your config file in your default editor:
 
-```shell
+```shell {filename="Terminal"}
 nd settings edit
 ```
 
@@ -216,7 +216,7 @@ nd settings edit
 
 To remove all nd-managed symlinks from your agent's config directory, run [`nd uninstall`](../reference/nd_uninstall.md):
 
-```shell
+```shell {filename="Terminal"}
 nd uninstall
 ```
 

--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -21,7 +21,7 @@ A deployable asset that configures how a coding agent behaves. Agent assets are 
 
 Not to be confused with [coding agent](#coding-agent), which is the AI tool (like Claude Code) that consumes agent assets.
 
-```text
+```text {filename="Source layout"}
 my-source/
 └── agents/
     └── code-reviewer.md    # This is an agent asset
@@ -80,7 +80,7 @@ See [How nd works](how-nd-works.md#context-files-the-exception) for deployment d
 
 Create a symlink from a coding agent's config directory to an asset in a source. Deploying does not copy files — it creates a link so that edits to the source appear instantly in the deployed location.
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting
 ```
 
@@ -104,7 +104,7 @@ Run `nd doctor` after editing config files or when deployments behave unexpected
 
 Package assets from a source into a standalone plugin directory or marketplace listing. Exporting is the deployment path for [plugins](#plugin) — unlike other asset types, plugins use `nd export` instead of symlink deployment.
 
-```shell
+```shell {filename="Terminal"}
 nd export                    # Export a plugin
 nd export marketplace        # Generate a marketplace listing
 ```
@@ -165,7 +165,7 @@ Like [hooks](#hook), output styles require manual registration in the coding age
 
 Lock a deployed asset so it persists across profile switches. nd neither removes nor redeploys pinned assets when you switch profiles.
 
-```shell
+```shell {filename="Terminal"}
 nd pin skills/greeting      # Lock the asset
 nd unpin skills/greeting    # Release the lock
 ```
@@ -182,7 +182,7 @@ Export plugins with `nd export` and generate marketplace listings with `nd expor
 
 A named collection of assets that you deploy and switch between as a group. Profiles work like browser profiles for your coding agent — for example, a "work" profile with enterprise tools and a "personal" profile with hobby project assets.
 
-```shell
+```shell {filename="Terminal"}
 nd profile create work --assets skills/jira,agents/reviewer
 nd profile switch personal
 ```
@@ -195,7 +195,7 @@ See [Profiles and snapshots](profiles-and-snapshots.md) for the full workflow.
 
 Delete a deployed symlink, disconnecting the asset from the coding agent's config directory. nd removes only the symlink, not the source file.
 
-```shell
+```shell {filename="Terminal"}
 nd remove skills/greeting
 ```
 
@@ -216,7 +216,7 @@ Where nd deploys an asset. nd supports two scopes:
 | `global` (default) | `~/.claude/` | `~/.copilot/` | Assets you want in every project |
 | `project` | `.claude/` | `.github/` | Assets specific to one project |
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting              # Global (default)
 nd deploy skills/greeting --scope project  # Project
 ```
@@ -229,7 +229,7 @@ A deployable asset that teaches a coding agent a reusable workflow or capability
 
 Skills are supported by Claude Code and Copilot CLI. Other coding agents may use different terminology for similar concepts (tools, instructions, prompts).
 
-```text
+```text {filename="Source layout"}
 my-source/
 └── skills/
     └── greeting/
@@ -242,7 +242,7 @@ A point-in-time record of all current deployments. Snapshots act as bookmarks yo
 
 nd creates auto-snapshots before destructive operations (profile switches, snapshot restores) as a safety net. nd retains the 5 most recent auto-snapshots.
 
-```shell
+```shell {filename="Terminal"}
 nd snapshot save before-experiment
 nd snapshot restore before-experiment
 ```
@@ -267,7 +267,7 @@ See [Create asset sources](creating-sources.md) for how to structure your own.
 
 Pull the latest changes from git sources and repair broken symlinks across all deployments. `nd sync` fixes [health status](#health-status) issues like broken, drifted, or orphaned symlinks.
 
-```shell
+```shell {filename="Terminal"}
 nd sync                        # Repair all deployments
 nd sync --source <source-id>   # Pull a git source and repair
 nd sync --dry-run              # Preview repairs without applying

--- a/docs/guide/how-nd-works.md
+++ b/docs/guide/how-nd-works.md
@@ -24,7 +24,7 @@ nd supports multiple agents. When no `--agent` flag is provided, nd targets the 
 
 nd wires each deployed asset from your source into the target agent's config directory:
 
-```text
+```text {filename="Source layout"}
   your source               nd               agent config dir
 ┌────────────────┐                        ┌──────────────────┐
 │ ~/my-assets/   │  ─── nd deploy ───▶    │ Claude Code:     │
@@ -41,7 +41,7 @@ The same source can serve multiple agents. nd creates links into whichever agent
 
 Here is a source directory with two assets: a skill (directory) and a rule (file):
 
-```text
+```text {filename="Source layout"}
 ~/my-assets/
 ├── skills/
 │   └── greeting/
@@ -52,7 +52,7 @@ Here is a source directory with two assets: a skill (directory) and a rule (file
 
 After running `nd deploy skills/greeting rules/no-emojis`, your agent's config directory looks like this:
 
-```text
+```text {filename="Source layout"}
 ~/.claude/                                              # Claude Code (default)
 ├── skills/
 │   └── greeting -> ~/my-assets/skills/greeting         # directory symlink
@@ -68,7 +68,7 @@ The `->` arrow shows where the symlink points. `greeting` is a directory symlink
 
 Verify this:
 
-```shell
+```shell {filename="Terminal"}
 ls -la ~/.claude/skills/
 # greeting -> /Users/you/my-assets/skills/greeting
 ```
@@ -84,7 +84,7 @@ nd deploys to one of two places depending on the scope. The exact directories de
 
 **Global scope** (default) deploys to the agent's user-wide config directory:
 
-```text
+```text {filename="Deployment paths"}
 # Claude Code
 ~/.claude/skills/greeting -> ~/my-assets/skills/greeting
 
@@ -94,7 +94,7 @@ nd deploys to one of two places depending on the scope. The exact directories de
 
 **Project scope** deploys to the current project's config directory:
 
-```text
+```text {filename="Deployment paths"}
 # Claude Code
 ~/myproject/.claude/skills/greeting -> ~/my-assets/skills/greeting
 
@@ -104,7 +104,7 @@ nd deploys to one of two places depending on the scope. The exact directories de
 
 Use global scope for assets you want everywhere. Use project scope for assets that only make sense in a specific repo.
 
-```shell
+```shell {filename="Terminal"}
 # Global (default)
 nd deploy skills/greeting
 
@@ -127,13 +127,13 @@ Claude Code reads context from a file named `CLAUDE.md`.
 
 **Global scope:** deploys into the agent's config directory:
 
-```text
+```text {filename="Deployment paths"}
 ~/.claude/CLAUDE.md -> ~/my-assets/context/go-project-rules/CLAUDE.md
 ```
 
 **Project scope:** deploys into the project root, NOT inside `.claude/`:
 
-```text
+```text {filename="Deployment paths"}
 ~/myproject/CLAUDE.md -> ~/my-assets/context/go-project-rules/CLAUDE.md
 ```
 
@@ -145,13 +145,13 @@ Copilot CLI reads context from a file named `copilot-instructions.md`.
 
 **Global scope:** deploys into the agent's config directory:
 
-```text
+```text {filename="Deployment paths"}
 ~/.copilot/copilot-instructions.md -> ~/my-assets/context/go-project-rules/CLAUDE.md
 ```
 
 **Project scope:** deploys into the project directory, NOT the project root:
 
-```text
+```text {filename="Deployment paths"}
 ~/myproject/.github/copilot-instructions.md -> ~/my-assets/context/go-project-rules/CLAUDE.md
 ```
 
@@ -174,19 +174,19 @@ nd supports two symlink strategies. The default is absolute:
 
 **Absolute** (default): the symlink target is a full path:
 
-```text
+```text {filename="Deployment paths"}
 ~/.claude/skills/greeting -> /Users/you/my-assets/skills/greeting
 ```
 
 **Relative:** the symlink target is a relative path from the link's location:
 
-```text
+```text {filename="Deployment paths"}
 ~/.claude/skills/greeting -> ../../my-assets/skills/greeting
 ```
 
 Absolute symlinks show the full path, making them more readable when debugging. Use relative symlinks if you sync your dotfiles across machines where your home directory path differs (different usernames or OS layouts).
 
-```shell
+```shell {filename="Terminal"}
 # Deploy with relative symlinks
 nd deploy skills/greeting --relative
 

--- a/docs/guide/profiles-and-snapshots.md
+++ b/docs/guide/profiles-and-snapshots.md
@@ -28,7 +28,7 @@ A **profile** is a named collection of assets: like browser profiles for your co
 
 Specify exactly which assets belong in the profile with [`nd profile create`](../reference/nd_profile_create.md):
 
-```shell
+```shell {filename="Terminal"}
 nd profile create work --assets skills/enterprise-auth,skills/jira-integration,agents/code-reviewer
 ```
 
@@ -36,13 +36,13 @@ nd profile create work --assets skills/enterprise-auth,skills/jira-integration,a
 
 Capture whatever is currently deployed:
 
-```shell
+```shell {filename="Terminal"}
 nd profile create work --from-current
 ```
 
 Add a description:
 
-```shell
+```shell {filename="Terminal"}
 nd profile create work --from-current --description "Enterprise development setup"
 ```
 
@@ -50,7 +50,7 @@ nd profile create work --from-current --description "Enterprise development setu
 
 Add assets to an existing profile one at a time with [`nd profile add-asset`](../reference/nd_profile_add-asset.md):
 
-```shell
+```shell {filename="Terminal"}
 nd profile add-asset work skills/new-skill
 nd profile add-asset work commands/deploy-staging
 ```
@@ -59,7 +59,7 @@ nd profile add-asset work commands/deploy-staging
 
 List all profiles with [`nd profile list`](../reference/nd_profile_list.md):
 
-```shell
+```shell {filename="Terminal"}
 nd profile list
 ```
 
@@ -69,7 +69,7 @@ nd marks the active profile with `*`.
 
 Deploy all assets from a profile with [`nd profile deploy`](../reference/nd_profile_deploy.md):
 
-```shell
+```shell {filename="Terminal"}
 nd profile deploy work
 ```
 
@@ -77,7 +77,7 @@ This resolves each asset reference from your registered sources and creates syml
 
 Preview first:
 
-```shell
+```shell {filename="Terminal"}
 nd profile deploy work --dry-run
 ```
 
@@ -85,7 +85,7 @@ nd profile deploy work --dry-run
 
 Switch from the current active profile to another with [`nd profile switch`](../reference/nd_profile_switch.md):
 
-```shell
+```shell {filename="Terminal"}
 nd profile switch personal
 ```
 
@@ -101,7 +101,7 @@ Before switching, nd automatically saves a snapshot (safety net). After confirmi
 
 Delete a profile with [`nd profile delete`](../reference/nd_profile_delete.md):
 
-```shell
+```shell {filename="Terminal"}
 nd profile delete work
 ```
 
@@ -111,7 +111,7 @@ This removes the profile definition but does **not** remove any currently deploy
 
 **Pinned assets persist across profile switches.** Use this for assets you always want available regardless of which profile is active.
 
-```shell
+```shell {filename="Terminal"}
 # Pin an asset
 nd pin skills/greeting
 
@@ -131,7 +131,7 @@ A **snapshot** is a point-in-time record of all current deployments. Think of it
 
 Save a snapshot with [`nd snapshot save`](../reference/nd_snapshot_save.md):
 
-```shell
+```shell {filename="Terminal"}
 nd snapshot save before-experiment
 ```
 
@@ -139,7 +139,7 @@ nd snapshot save before-experiment
 
 List all snapshots with [`nd snapshot list`](../reference/nd_snapshot_list.md):
 
-```shell
+```shell {filename="Terminal"}
 nd snapshot list
 ```
 
@@ -149,7 +149,7 @@ The list shows both user-created and auto-created snapshots. nd tags auto-snapsh
 
 Restore a snapshot with [`nd snapshot restore`](../reference/nd_snapshot_restore.md):
 
-```shell
+```shell {filename="Terminal"}
 nd snapshot restore before-experiment
 ```
 
@@ -161,7 +161,7 @@ Run `nd snapshot restore` with no arguments to get an interactive picker.
 
 Delete a snapshot with [`nd snapshot delete`](../reference/nd_snapshot_delete.md):
 
-```shell
+```shell {filename="Terminal"}
 nd snapshot delete old-snapshot
 ```
 
@@ -173,7 +173,7 @@ nd automatically saves snapshots before destructive operations like profile swit
 
 Here is a complete workflow using profiles, pinning, and snapshots:
 
-```shell
+```shell {filename="Terminal"}
 # Create two profiles
 nd profile create work --assets skills/jira,skills/enterprise-auth,agents/reviewer
 nd profile create personal --assets skills/blog-writer,skills/recipe-helper

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -28,7 +28,7 @@ Start with [`nd doctor`](../reference/nd_doctor.md) to identify the category of 
 | Agents | Each configured agent is detected on the system; global config directory exists |
 | Git | `git` binary is available in `$PATH` |
 
-```shell
+```shell {filename="Terminal"}
 # Run all checks
 nd doctor
 
@@ -53,7 +53,7 @@ nd doctor --json
 
 Use [`nd sync`](../reference/nd_sync.md) to repair broken symlinks:
 
-```shell
+```shell {filename="Terminal"}
 # Repair all broken symlinks
 nd sync
 
@@ -79,7 +79,7 @@ nd doctor
 
 **Fix:**
 
-```shell
+```shell {filename="Terminal"}
 # Verify the registered path
 nd source list
 
@@ -104,7 +104,7 @@ Use [`nd settings edit`](../reference/nd_settings_edit.md) to fix source paths. 
 
 **Fix:**
 
-```shell
+```shell {filename="Terminal"}
 # Validate config (doctor checks this first)
 nd doctor
 
@@ -131,7 +131,7 @@ If a project config exists, check `.nd/config.yaml` in your project root. Projec
 
 **Fix:**
 
-```shell
+```shell {filename="Terminal"}
 # Check origin of each deployed asset
 nd status
 
@@ -152,7 +152,7 @@ The `nd status` output shows the origin of each asset: `manual`, `pinned`, or th
 
 **Fix:**
 
-```shell
+```shell {filename="Terminal"}
 # Check for backed-up context files
 ls ~/.config/nd/backups/
 
@@ -174,7 +174,7 @@ See [Context files](asset-types/context.md) for the special scoping rules that d
 
 **Fix:**
 
-```shell
+```shell {filename="Terminal"}
 # Check if the agent binary exists
 which claude        # Claude Code
 which copilot       # Copilot CLI
@@ -194,13 +194,13 @@ nd settings edit
 
 **Fix:** Use the `type/name` format to disambiguate:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting
 ```
 
 Or use the `--type` flag:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy --type skills greeting
 ```
 
@@ -212,7 +212,7 @@ nd deploy --type skills greeting
 
 **Fix:** Pass `--yes` to skip the confirmation:
 
-```shell
+```shell {filename="Terminal"}
 nd source remove my-assets --yes
 ```
 
@@ -224,7 +224,7 @@ nd source remove my-assets --yes
 
 **Fix:** Use `nd settings edit` to modify your existing config. If you need to start fresh, delete the config first:
 
-```shell
+```shell {filename="Terminal"}
 rm ~/.config/nd/config.yaml && nd init
 ```
 
@@ -236,7 +236,7 @@ rm ~/.config/nd/config.yaml && nd init
 
 **Fix:** Specify the profile name explicitly:
 
-```shell
+```shell {filename="Terminal"}
 nd profile deploy my-setup
 ```
 
@@ -250,7 +250,7 @@ Or switch to a profile first with [`nd profile switch`](../reference/nd_profile_
 
 **Fix:** Move or remove the conflicting file, then retry the deploy:
 
-```shell
+```shell {filename="Terminal"}
 # Claude Code example (Copilot CLI equivalent: ~/.copilot/copilot-instructions.md)
 mv ~/.claude/CLAUDE.md ~/.claude/CLAUDE.md.bak
 nd deploy context/my-rules

--- a/docs/guide/user-guide.md
+++ b/docs/guide/user-guide.md
@@ -43,7 +43,7 @@ These flags work with every command:
 
 Example scripted workflow:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --yes --json | jq '.status'
 ```
 
@@ -53,7 +53,7 @@ nd deploy skills/greeting --yes --json | jq '.status'
 
 Add a source with [`nd source add`](../reference/nd_source_add.md):
 
-```shell
+```shell {filename="Terminal"}
 nd source add ~/my-assets
 nd source add ~/my-assets --alias my-stuff
 ```
@@ -62,7 +62,7 @@ nd scans the directory for convention-based subdirectories (`skills/`, `agents/`
 
 ### Add a git repository
 
-```shell
+```shell {filename="Terminal"}
 # GitHub shorthand
 nd source add owner/repo
 
@@ -79,7 +79,7 @@ Git sources are cloned to `~/.config/nd/sources/` and can be synced later.
 
 List registered sources with [`nd source list`](../reference/nd_source_list.md):
 
-```shell
+```shell {filename="Terminal"}
 nd source list
 ```
 
@@ -89,7 +89,7 @@ Output shows source ID, type (`local`, `git`, or `builtin`), asset count, and pa
 
 Pull the latest changes from a git source with [`nd sync`](../reference/nd_sync.md):
 
-```shell
+```shell {filename="Terminal"}
 nd sync --source <source-id>
 ```
 
@@ -99,7 +99,7 @@ This runs `git pull --ff-only` and then repairs any broken symlinks.
 
 Remove a source with [`nd source remove`](../reference/nd_source_remove.md):
 
-```shell
+```shell {filename="Terminal"}
 nd source remove <source-id>
 ```
 
@@ -113,7 +113,7 @@ For a visual walkthrough of what deploy does on disk, see [How nd works](how-nd-
 
 ### Single asset
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting
 ```
 
@@ -121,13 +121,13 @@ Asset references use the format `type/name`. If the name is unique across types,
 
 ### Filter by type
 
-```shell
+```shell {filename="Terminal"}
 nd deploy --type skills greeting
 ```
 
 ### Multiple assets
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting commands/hello agents/researcher
 ```
 
@@ -138,7 +138,7 @@ Bulk operations continue on per-asset failure and report a summary.
 - **Global** (`--scope global`, default): Deploys to your agent's global config directory (`~/.claude/` for Claude Code, `~/.copilot/` for Copilot CLI)
 - **Project** (`--scope project`): Deploys to the project-level config directory (`.claude/` for Claude Code, `.github/` for Copilot CLI)
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --scope project
 ```
 
@@ -146,7 +146,7 @@ nd deploy skills/greeting --scope project
 
 Use `--agent` to deploy to a particular agent:
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --agent copilot
 ```
 
@@ -159,7 +159,7 @@ When no `--agent` flag is provided, nd deploys to the configured default agent i
 - **Absolute** (default): Symlinks use absolute paths
 - **Relative** (`--relative`): Symlinks use relative paths (better for portable setups)
 
-```shell
+```shell {filename="Terminal"}
 nd deploy skills/greeting --relative
 ```
 
@@ -167,7 +167,7 @@ The default strategy can be changed in your config file (`symlink_strategy: rela
 
 ## Remove assets
 
-```shell
+```shell {filename="Terminal"}
 nd remove skills/greeting
 ```
 
@@ -181,7 +181,7 @@ Run `nd remove` with no arguments to get an interactive picker of deployed asset
 
 Use [`nd list`](../reference/nd_list.md) to browse assets:
 
-```shell
+```shell {filename="Terminal"}
 # All assets
 nd list
 
@@ -201,7 +201,7 @@ Assets marked with `*` are currently deployed.
 
 Run [`nd status`](../reference/nd_status.md) to see what is deployed:
 
-```shell
+```shell {filename="Terminal"}
 nd status
 ```
 
@@ -214,7 +214,7 @@ Shows all deployed assets with:
 
 ### JSON output
 
-```shell
+```shell {filename="Terminal"}
 nd list --json
 nd status --json
 ```
@@ -223,7 +223,7 @@ nd status --json
 
 Open your config file in your default editor (`$EDITOR`, `$VISUAL`, or `vi`) with [`nd settings edit`](../reference/nd_settings_edit.md):
 
-```shell
+```shell {filename="Terminal"}
 nd settings edit
 ```
 
@@ -233,19 +233,19 @@ See [Configuration](configuration.md) for all available settings.
 
 Fix broken symlinks across all deployments:
 
-```shell
+```shell {filename="Terminal"}
 nd sync
 ```
 
 Sync a specific git source (pull + repair):
 
-```shell
+```shell {filename="Terminal"}
 nd sync --source <source-id>
 ```
 
 Preview what would be repaired:
 
-```shell
+```shell {filename="Terminal"}
 nd sync --dry-run
 ```
 
@@ -253,7 +253,7 @@ nd sync --dry-run
 
 Run a comprehensive health check with [`nd doctor`](../reference/nd_doctor.md):
 
-```shell
+```shell {filename="Terminal"}
 nd doctor
 ```
 
@@ -271,7 +271,7 @@ nd records every mutating operation to a JSONL log file at `~/.config/nd/logs/op
 
 ### View the log
 
-```shell
+```shell {filename="Terminal"}
 # Last 10 operations
 tail -10 ~/.config/nd/logs/operations.log
 
@@ -307,7 +307,7 @@ Dry-run operations (`--dry-run`) do not write log entries.
 
 Generate and install shell completions with [`nd completion`](../reference/nd_completion.md):
 
-```shell
+```shell {filename="Terminal"}
 # Print completion script
 nd completion bash
 nd completion zsh
@@ -324,7 +324,7 @@ nd completion zsh --install-dir ~/.my-completions
 
 For zsh, ensure your `~/.zshrc` includes:
 
-```shell
+```shell {filename="Terminal"}
 fpath+=~/.zfunc
 autoload -Uz compinit && compinit
 ```
@@ -333,7 +333,7 @@ autoload -Uz compinit && compinit
 
 Remove all nd-managed symlinks from agent config directories with [`nd uninstall`](../reference/nd_uninstall.md):
 
-```shell
+```shell {filename="Terminal"}
 nd uninstall
 ```
 

--- a/docs/reference/nd.md
+++ b/docs/reference/nd.md
@@ -10,13 +10,13 @@ Napoleon Dynamite - coding agent asset manager
 
 nd manages coding agent assets (skills, commands, rules, etc.) via symlink deployment.
 
-```
+```shell {filename="Terminal"}
 nd [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Deploy an asset
   nd deploy skills/greeting
 
@@ -32,7 +32,7 @@ nd [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_completion.md
+++ b/docs/reference/nd_completion.md
@@ -16,7 +16,7 @@ Run "nd completion <shell> --help" for shell-specific instructions.
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   nd completion bash
   nd completion zsh --install
   nd completion fish
@@ -24,13 +24,13 @@ Run "nd completion <shell> --help" for shell-specific instructions.
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for completion
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_completion_bash.md
+++ b/docs/reference/nd_completion_bash.md
@@ -18,13 +18,13 @@ Or manually:
 
 Then restart your shell or source the file.
 
-```
+```shell {filename="Terminal"}
 nd completion bash [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Print bash completion script
   nd completion bash
 
@@ -34,7 +34,7 @@ nd completion bash [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help                 help for bash
       --install              install to standard location
       --install-dir string   override install directory
@@ -42,7 +42,7 @@ nd completion bash [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_completion_fish.md
+++ b/docs/reference/nd_completion_fish.md
@@ -16,13 +16,13 @@ To install completions:
 Or manually:
   nd completion fish > ~/.config/fish/completions/nd.fish
 
-```
+```shell {filename="Terminal"}
 nd completion fish [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Print fish completion script
   nd completion fish
 
@@ -32,7 +32,7 @@ nd completion fish [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help                 help for fish
       --install              install to standard location
       --install-dir string   override install directory
@@ -40,7 +40,7 @@ nd completion fish [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_completion_zsh.md
+++ b/docs/reference/nd_completion_zsh.md
@@ -20,13 +20,13 @@ Then add to ~/.zshrc (if not already present):
   fpath+=~/.zfunc
   autoload -Uz compinit && compinit
 
-```
+```shell {filename="Terminal"}
 nd completion zsh [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Print zsh completion script
   nd completion zsh
 
@@ -39,7 +39,7 @@ nd completion zsh [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help                 help for zsh
       --install              install to standard location
       --install-dir string   override install directory
@@ -47,7 +47,7 @@ nd completion zsh [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_deploy.md
+++ b/docs/reference/nd_deploy.md
@@ -14,13 +14,13 @@ Asset references can be:
   name Search all types for matching name
   type/name Search specific type (e.g., skills/greeting)
 
-```
+```shell {filename="Terminal"}
 nd deploy <asset> [assets...] [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Deploy a single asset
   nd deploy skills/greeting
 
@@ -45,7 +45,7 @@ nd deploy <asset> [assets...] [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
       --absolute      use absolute symlinks (overrides config)
   -h, --help          help for deploy
       --relative      use relative symlinks (overrides config)
@@ -54,7 +54,7 @@ nd deploy <asset> [assets...] [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_doctor.md
+++ b/docs/reference/nd_doctor.md
@@ -6,13 +6,13 @@ weight: 70
 
 Check nd configuration and deployment health
 
-```
+```shell {filename="Terminal"}
 nd doctor [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Run a full health check
   nd doctor
 
@@ -22,13 +22,13 @@ nd doctor [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for doctor
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_export.md
+++ b/docs/reference/nd_export.md
@@ -13,13 +13,13 @@ Export one or more nd-managed assets into the Claude Code plugin format.
 Assets are specified with --assets in type/name format (e.g., skills/greeting).
 Multiple assets can be comma-separated or the flag repeated.
 
-```
+```shell {filename="Terminal"}
 nd export [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Export assets as a Claude Code plugin
   nd export --assets skills/greeting,commands/hello --output ./my-plugin
 
@@ -29,7 +29,7 @@ nd export [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
       --assets strings       assets to export (type/name format, comma-separated)
       --author string        author name
       --description string   plugin description
@@ -45,7 +45,7 @@ nd export [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_export_marketplace.md
+++ b/docs/reference/nd_export_marketplace.md
@@ -12,20 +12,20 @@ Generate a marketplace directory structure from one or more previously exported 
 
 Each --plugins path must point to a directory containing a .claude-plugin/plugin.json file.
 
-```
+```shell {filename="Terminal"}
 nd export marketplace [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Generate marketplace from exported plugins
   nd export marketplace --plugins ./plugin-a,./plugin-b --output ./marketplace
 ```
 
 ## Options
 
-```
+```text {filename="Flags"}
       --description string   marketplace description
       --email string         owner email
   -h, --help                 help for marketplace
@@ -38,7 +38,7 @@ nd export marketplace [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_init.md
+++ b/docs/reference/nd_init.md
@@ -14,13 +14,13 @@ Creates the config directory structure, writes a default config file, and
 deploys built-in assets (skills, commands, agents) to your coding agent's
 config directory. Use --yes to skip the deploy confirmation prompt.
 
-```
+```shell {filename="Terminal"}
 nd init [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Interactive setup
   nd init
 
@@ -30,13 +30,13 @@ nd init [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for init
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_list.md
+++ b/docs/reference/nd_list.md
@@ -6,13 +6,13 @@ weight: 110
 
 List available assets from all sources
 
-```
+```shell {filename="Terminal"}
 nd list [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # List all available assets
   nd list
 
@@ -31,7 +31,7 @@ nd list [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help             help for list
       --pattern string   filter by name pattern
       --source string    filter by source ID
@@ -40,7 +40,7 @@ nd list [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_pin.md
+++ b/docs/reference/nd_pin.md
@@ -6,13 +6,13 @@ weight: 120
 
 Pin an asset to prevent profile switches from removing it
 
-```
+```shell {filename="Terminal"}
 nd pin <asset> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Pin an asset to survive profile switches
   nd pin skills/greeting
 
@@ -22,13 +22,13 @@ nd pin <asset> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for pin
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile.md
+++ b/docs/reference/nd_profile.md
@@ -12,7 +12,7 @@ Create, list, deploy, and switch between named profiles.
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   nd profile create my-setup
   nd profile list
   nd profile switch my-setup
@@ -20,13 +20,13 @@ Create, list, deploy, and switch between named profiles.
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for profile
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile_add-asset.md
+++ b/docs/reference/nd_profile_add-asset.md
@@ -6,13 +6,13 @@ weight: 140
 
 Add an asset to an existing profile
 
-```
+```shell {filename="Terminal"}
 nd profile add-asset <profile> <asset> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Add an asset to an existing profile
   nd profile add-asset my-setup skills/greeting
 
@@ -22,13 +22,13 @@ nd profile add-asset <profile> <asset> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for add-asset
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile_create.md
+++ b/docs/reference/nd_profile_create.md
@@ -6,13 +6,13 @@ weight: 150
 
 Create a new profile
 
-```
+```shell {filename="Terminal"}
 nd profile create <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Create a profile from current deployments
   nd profile create my-setup
 
@@ -22,7 +22,7 @@ nd profile create <name> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
       --assets string        comma-separated list of assets (type/name)
       --description string   profile description
       --from-current         create profile from current deployments
@@ -31,7 +31,7 @@ nd profile create <name> [flags]
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile_delete.md
+++ b/docs/reference/nd_profile_delete.md
@@ -6,13 +6,13 @@ weight: 160
 
 Delete a profile
 
-```
+```shell {filename="Terminal"}
 nd profile delete <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Delete a profile
   nd profile delete my-setup
 
@@ -22,13 +22,13 @@ nd profile delete <name> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for delete
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile_deploy.md
+++ b/docs/reference/nd_profile_deploy.md
@@ -6,13 +6,13 @@ weight: 170
 
 Deploy all assets in a profile
 
-```
+```shell {filename="Terminal"}
 nd profile deploy <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Deploy all assets in a profile
   nd profile deploy my-setup
 
@@ -22,13 +22,13 @@ nd profile deploy <name> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for deploy
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile_list.md
+++ b/docs/reference/nd_profile_list.md
@@ -6,13 +6,13 @@ weight: 180
 
 List all profiles
 
-```
+```shell {filename="Terminal"}
 nd profile list [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # List all saved profiles
   nd profile list
 
@@ -22,13 +22,13 @@ nd profile list [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for list
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_profile_switch.md
+++ b/docs/reference/nd_profile_switch.md
@@ -6,13 +6,13 @@ weight: 190
 
 Switch from current profile to another
 
-```
+```shell {filename="Terminal"}
 nd profile switch <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Switch to a different profile
   nd profile switch my-setup
 
@@ -22,13 +22,13 @@ nd profile switch <name> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for switch
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_remove.md
+++ b/docs/reference/nd_remove.md
@@ -6,13 +6,13 @@ weight: 200
 
 Remove deployed assets
 
-```
+```shell {filename="Terminal"}
 nd remove <asset> [assets...] [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Remove a deployed asset
   nd remove skills/greeting
 
@@ -28,13 +28,13 @@ nd remove <asset> [assets...] [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for remove
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_settings.md
+++ b/docs/reference/nd_settings.md
@@ -8,19 +8,19 @@ Manage nd settings
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   nd settings edit
 ```
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for settings
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_settings_edit.md
+++ b/docs/reference/nd_settings_edit.md
@@ -6,26 +6,26 @@ weight: 220
 
 Open settings in your editor
 
-```
+```shell {filename="Terminal"}
 nd settings edit [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Open config in your default editor
   nd settings edit
 ```
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for edit
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_snapshot.md
+++ b/docs/reference/nd_snapshot.md
@@ -12,7 +12,7 @@ Save, restore, list, and delete point-in-time deployment snapshots.
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   nd snapshot save before-update
   nd snapshot list
   nd snapshot restore before-update
@@ -20,13 +20,13 @@ Save, restore, list, and delete point-in-time deployment snapshots.
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for snapshot
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_snapshot_delete.md
+++ b/docs/reference/nd_snapshot_delete.md
@@ -6,13 +6,13 @@ weight: 240
 
 Delete a snapshot
 
-```
+```shell {filename="Terminal"}
 nd snapshot delete <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Delete a snapshot
   nd snapshot delete before-update
 
@@ -22,13 +22,13 @@ nd snapshot delete <name> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for delete
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_snapshot_list.md
+++ b/docs/reference/nd_snapshot_list.md
@@ -6,13 +6,13 @@ weight: 250
 
 List all snapshots
 
-```
+```shell {filename="Terminal"}
 nd snapshot list [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # List all snapshots
   nd snapshot list
 
@@ -22,13 +22,13 @@ nd snapshot list [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for list
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_snapshot_restore.md
+++ b/docs/reference/nd_snapshot_restore.md
@@ -6,13 +6,13 @@ weight: 260
 
 Restore deployments from a snapshot
 
-```
+```shell {filename="Terminal"}
 nd snapshot restore <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Restore deployments from a snapshot
   nd snapshot restore before-update
 
@@ -22,13 +22,13 @@ nd snapshot restore <name> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for restore
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_snapshot_save.md
+++ b/docs/reference/nd_snapshot_save.md
@@ -6,26 +6,26 @@ weight: 270
 
 Save current deployments as a named snapshot
 
-```
+```shell {filename="Terminal"}
 nd snapshot save <name> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Save current deployments as a snapshot
   nd snapshot save before-update
 ```
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for save
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_source.md
+++ b/docs/reference/nd_source.md
@@ -12,7 +12,7 @@ Add, remove, and list asset source directories.
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   nd source add ~/my-assets
   nd source list
   nd source remove my-assets
@@ -20,13 +20,13 @@ Add, remove, and list asset source directories.
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for source
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_source_add.md
+++ b/docs/reference/nd_source_add.md
@@ -6,13 +6,13 @@ weight: 290
 
 Register a new asset source
 
-```
+```shell {filename="Terminal"}
 nd source add <path|url> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Add a local directory
   nd source add ~/my-assets
 
@@ -31,14 +31,14 @@ nd source add <path|url> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
       --alias string   human-readable alias for the source
   -h, --help           help for add
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_source_list.md
+++ b/docs/reference/nd_source_list.md
@@ -6,13 +6,13 @@ weight: 300
 
 List registered sources
 
-```
+```shell {filename="Terminal"}
 nd source list [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # List all registered sources
   nd source list
 
@@ -22,13 +22,13 @@ nd source list [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for list
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_source_remove.md
+++ b/docs/reference/nd_source_remove.md
@@ -6,13 +6,13 @@ weight: 310
 
 Remove a registered source
 
-```
+```shell {filename="Terminal"}
 nd source remove <source-id> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Remove a source by ID
   nd source remove my-assets
 
@@ -22,13 +22,13 @@ nd source remove <source-id> [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for remove
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_status.md
+++ b/docs/reference/nd_status.md
@@ -6,13 +6,13 @@ weight: 320
 
 Show deployment status and health
 
-```
+```shell {filename="Terminal"}
 nd status [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Show all deployed assets and their health
   nd status
 
@@ -25,13 +25,13 @@ nd status [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for status
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_sync.md
+++ b/docs/reference/nd_sync.md
@@ -6,13 +6,13 @@ weight: 330
 
 Repair symlinks and optionally pull git sources
 
-```
+```shell {filename="Terminal"}
 nd sync [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Repair all broken symlinks
   nd sync
 
@@ -25,14 +25,14 @@ nd sync [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help            help for sync
       --source string   sync a specific git source
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_uninstall.md
+++ b/docs/reference/nd_uninstall.md
@@ -6,13 +6,13 @@ weight: 340
 
 Remove all nd-managed symlinks and optionally config
 
-```
+```shell {filename="Terminal"}
 nd uninstall [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Remove all nd-managed symlinks
   nd uninstall
 
@@ -22,13 +22,13 @@ nd uninstall [flags]
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for uninstall
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_unpin.md
+++ b/docs/reference/nd_unpin.md
@@ -6,26 +6,26 @@ weight: 350
 
 Unpin an asset, allowing profile switches to manage it
 
-```
+```shell {filename="Terminal"}
 nd unpin <asset> [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   # Unpin an asset
   nd unpin skills/greeting
 ```
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for unpin
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/docs/reference/nd_version.md
+++ b/docs/reference/nd_version.md
@@ -6,25 +6,25 @@ weight: 360
 
 Print nd version information
 
-```
+```shell {filename="Terminal"}
 nd version [flags]
 ```
 
 ## Examples
 
-```
+```shell {filename="Terminal"}
   nd version
 ```
 
 ## Options
 
-```
+```text {filename="Flags"}
   -h, --help   help for version
 ```
 
 ## Options inherited from parent commands
 
-```
+```text {filename="Flags"}
       --agent string    target agent (e.g., claude-code, copilot)
       --config string   path to config file (default "~/.config/nd/config.yaml")
       --dry-run         show what would happen without making changes

--- a/site/assets/css/custom.css
+++ b/site/assets/css/custom.css
@@ -205,8 +205,11 @@
   color: #a6adc8;
 }
 
-.nd-code-header + div .chroma {
-  border-radius: 0 0 0.375rem 0.375rem;
+.hextra-code-block .nd-code-header + div,
+.hextra-code-block .nd-code-header + div .highlight,
+.hextra-code-block .nd-code-header + div pre:not(.lntable pre),
+.hextra-code-block .nd-code-header + div .chroma {
+  border-radius: 0 0 0.375rem 0.375rem !important;
 }
 
 .nd-dots {

--- a/site/content/docs/about.md
+++ b/site/content/docs/about.md
@@ -18,7 +18,7 @@ nd creates symlinks from your agent's config directory to asset sources (local d
 
 ## Install
 
-```shell
+```shell {filename="Terminal"}
 # Homebrew (macOS/Linux)
 brew install armstrongl/tap/nd
 


### PR DESCRIPTION
## Summary

- Updates all 36 CLI reference pages to use the enhanced code block features from #87
- Synopsis/Examples blocks now use `shell {filename="Terminal"}` for syntax highlighting and terminal frame headers
- Options blocks now use `text {filename="Flags"}` for labeled frame headers that distinguish flag listings from commands
- Brings CLI reference pages in line with the glossary and guide pages that already use these features

## Context

PR #87 introduced enhanced code blocks with Catppuccin syntax themes, macOS-style terminal frame headers, and per-line hover highlighting. These features are opt-in via language identifiers and the `filename=` attribute on code fences. The CLI reference pages were still using bare ` ``` ` fences with no language ID, so they rendered without any of these enhancements.

## Test plan

- [x] Verify Hugo builds cleanly (`hugo --gc --minify` in `site/`)
- [x] Spot-check a few CLI reference pages in the browser for terminal frame rendering
- [x] Confirm Options blocks render with "Flags" header, not "Terminal"
- [x] Confirm glossary page still renders correctly (no regressions)