### PR TITLE
feat(ci): add automated AFDocs compliance checking

### DIFF
--- a/.github/workflows/afdocs-check.yml
+++ b/.github/workflows/afdocs-check.yml
@@ -1,0 +1,129 @@
+name: AFDocs check
+
+on:
+  workflow_run:
+    workflows: ["Deploy docs"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  actions: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event_name == 'workflow_dispatch'
+    timeout-minutes: 10
+    env:
+      SITE_URL: "https://armstrongl.github.io/nd/"
+      AFDOCS_VERSION: "0.10.1"
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run AFDocs check (JSON report)
+        id: json_check
+        run: |
+          EXIT_CODE=0
+          npx -y "afdocs@${AFDOCS_VERSION}" check "${SITE_URL}" \
+            --format json \
+            --score \
+            --sampling deterministic > afdocs-report.json || EXIT_CODE=$?
+          echo "exit_code=${EXIT_CODE}" >> "$GITHUB_OUTPUT"
+
+      - name: Run AFDocs check (scorecard)
+        run: |
+          npx -y "afdocs@${AFDOCS_VERSION}" check "${SITE_URL}" \
+            --format scorecard \
+            --fixes \
+            --sampling deterministic > afdocs-scorecard.txt || true
+
+      - name: Upload JSON report
+        uses: actions/upload-artifact@v4
+        with:
+          name: afdocs-report
+          path: afdocs-report.json
+          retention-days: 14
+
+      - name: Ensure afdocs-check label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create afdocs-check \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "fbca04" \
+            --description "AFDocs compliance check" \
+            --force
+
+      - name: Find open afdocs-check issue
+        id: find_issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUE_NUMBER=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label afdocs-check \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or update issue on failure
+        if: steps.json_check.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "## AFDocs Compliance Check Failed"
+            echo ""
+            echo "**Run:** [${GITHUB_RUN_ID}](${WORKFLOW_URL})"
+            echo "**Site:** ${SITE_URL}"
+            echo "**Date:** $(date -u +'%Y-%m-%d %H:%M UTC')"
+            echo ""
+            echo "### Scorecard"
+            echo ""
+            echo '```'
+            if [ -s afdocs-scorecard.txt ]; then
+              cat afdocs-scorecard.txt
+            else
+              echo "Check produced no output. See workflow run for details."
+            fi
+            echo '```'
+            echo ""
+            echo "---"
+            echo "*This issue is automatically managed by the [AFDocs check workflow](${WORKFLOW_URL}). It will be closed when the next check passes.*"
+          } > issue-body.md
+
+          if [ "${{ steps.find_issue.outputs.exists }}" = "true" ]; then
+            gh issue edit "${{ steps.find_issue.outputs.number }}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file issue-body.md
+          else
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "AFDocs compliance check failing" \
+              --label afdocs-check \
+              --body-file issue-body.md
+          fi
+
+      - name: Close issue on pass
+        if: steps.json_check.outputs.exit_code == '0' && steps.find_issue.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          gh issue close "${{ steps.find_issue.outputs.number }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --comment "AFDocs check passed in [run ${GITHUB_RUN_ID}](${WORKFLOW_URL})."

--- a/.github/workflows/afdocs-check.yml
+++ b/.github/workflows/afdocs-check.yml
@@ -127,3 +127,9 @@ jobs:
           gh issue close "${{ steps.find_issue.outputs.number }}" \
             --repo "$GITHUB_REPOSITORY" \
             --comment "AFDocs check passed in [run ${GITHUB_RUN_ID}](${WORKFLOW_URL})."
+
+      - name: Fail workflow on compliance failure
+        if: steps.json_check.outputs.exit_code != '0'
+        run: |
+          echo "AFDocs compliance check failed (exit code: ${{ steps.json_check.outputs.exit_code }})"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install rumdl
-        run: pip install rumdl==0.1.64
+        run: pip install rumdl==0.1.69
       - name: Lint
         run: rumdl check .
 

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -45,7 +45,7 @@ punctuation = ".,;:!"
 # Sentence-case headings (capitalize first word and proper nouns only).
 [MD063]
 style = "sentence-case"
-ignore-words = ["nd", "Napoleon Dynamite"]
+ignore-words = ["nd", "Napoleon", "Dynamite"]
 preserve-cased-words = true
 
 # --- List rules ---

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -45,7 +45,7 @@ punctuation = ".,;:!"
 # Sentence-case headings (capitalize first word and proper nouns only).
 [MD063]
 style = "sentence-case"
-ignore-words = ["nd"]
+ignore-words = ["nd", "Napoleon Dynamite"]
 preserve-cased-words = true
 
 # --- List rules ---

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Go](https://img.shields.io/github/go-mod/go-version/armstrongl/nd)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/armstrongl/nd)](https://github.com/armstrongl/nd/releases)
+[![AFDocs check](https://github.com/armstrongl/nd/actions/workflows/afdocs-check.yml/badge.svg)](https://github.com/armstrongl/nd/actions/workflows/afdocs-check.yml)
 <!-- rumdl-enable MD044 -->
 
 > [!WARNING]


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically validates AFDocs compliance after every successful docs deployment. Failures create a deduplicated GitHub issue; passing runs auto-close it. Completes the remaining scope of #76.

## How it works

The `afdocs-check.yml` workflow triggers via `workflow_run` after "Deploy docs" succeeds, plus `workflow_dispatch` for manual reruns. It runs `npx afdocs@0.10.1 check` twice against the live Pages site:

1. **JSON report** (`--format json --score`) — uploaded as a 14-day artifact for investigation
2. **Scorecard** (`--format scorecard --fixes`) — embedded in the GitHub issue body for at-a-glance status

Issue management uses `gh` CLI with deduplication: searches for an open `afdocs-check`-labeled issue, creates or updates on failure, closes with a comment on pass. The `afdocs-check` label is created idempotently via `gh label create --force`.

A README badge links to the workflow's latest status.

## Key decisions

- **`gh` CLI over marketplace actions** for issue management — the conditional create/update/close logic doesn't map to any single action. `gh` is pre-installed on runners.
- **Two `afdocs` invocations** — simpler than parsing JSON into markdown. `--sampling deterministic` ensures consistent results across both.
- **No propagation polling** — if Pages hasn't propagated, the check fails and creates an issue. Self-correcting on the next deploy. `workflow_dispatch` provides manual recovery.
- **Pin `afdocs@0.10.1`** — 0.x series is explicitly unstable.

## Test plan

- [ ] Trigger via `workflow_dispatch` after merge — verify both afdocs runs complete, JSON artifact uploads, and issue is created (known Hextra theme failures will cause a fail)
- [ ] Verify issue body contains scorecard output and workflow run link
- [ ] Trigger a second `workflow_dispatch` run — verify the existing issue is updated (not duplicated)
- [ ] Verify `workflow_run` path fires on next docs deployment to `main`
- [ ] Verify README badge renders and links to the workflow page

## Post-Deploy Monitoring & Validation

- **Watch:** GitHub Actions tab for `AFDocs check` workflow runs after the next docs deployment
- **Healthy signal:** Workflow completes, JSON artifact uploaded, issue created/updated with scorecard content
- **Failure signal:** Workflow fails before reaching issue management steps (Node.js setup failure, npm registry outage)
- **Rollback:** Delete the workflow file; no other files or services affected
- **Validation window:** First `workflow_run`-triggered execution after merge

---

[![Compound Engineering v2.62.0](https://img.shields.io/badge/Compound_Engineering-v2.62.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)