### PR TITLE
feat: let user select target agents for deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ site/public/
 site/resources/
 site/.hugo_build.lock
 site/_vendor/
+nd

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ site/public/
 site/resources/
 site/.hugo_build.lock
 site/_vendor/
-nd
+/nd

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -91,7 +91,7 @@ func (a *App) ActiveAgent() (*agent.Agent, error) {
 	return reg.Default()
 }
 
-// DeployEngine returns the deploy engine, creating it on first call.
+// DeployEngine returns the deploy engine for the active agent, creating it on first call.
 func (a *App) DeployEngine() (*deploy.Engine, error) {
 	if a.eng != nil {
 		return a.eng, nil
@@ -100,17 +100,25 @@ func (a *App) DeployEngine() (*deploy.Engine, error) {
 	if err != nil {
 		return nil, err
 	}
+	eng, err := a.DeployEngineFor(ag)
+	if err != nil {
+		return nil, err
+	}
+	a.eng = eng
+	return a.eng, nil
+}
+
+// DeployEngineFor creates a deploy engine for the given agent.
+func (a *App) DeployEngineFor(ag *agent.Agent) (*deploy.Engine, error) {
 	sstore := a.StateStore()
 	eng := deploy.New(sstore, ag, a.BackupDir)
 
-	// Wire auto-snapshot saver
 	pstore, err := a.ProfileStore()
 	if err == nil {
 		eng.SetSnapshotSaver(pstore)
 	}
 
-	a.eng = eng
-	return a.eng, nil
+	return eng, nil
 }
 
 // ProfileManager returns the profile manager, creating it on first call.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/armstrongl/nd/internal/agent"
 	"github.com/armstrongl/nd/internal/asset"
 	"github.com/armstrongl/nd/internal/deploy"
 	"github.com/armstrongl/nd/internal/nd"
@@ -15,6 +16,7 @@ import (
 func newDeployCmd(app *App) *cobra.Command {
 	var (
 		assetType string
+		agents    []string
 		relative  bool
 		absolute  bool
 	)
@@ -110,13 +112,57 @@ Asset references can be:
 				assets = append(assets, *resolved)
 			}
 
-			eng, err := app.DeployEngine()
+			// Resolve target agents: --agents > config default_deploy_agents > ActiveAgent
+			reg, err := app.AgentRegistry()
 			if err != nil {
 				return err
 			}
+			reg.Detect()
 
-			// Prune ghost deployments for all agents (best-effort pre-op cleanup)
-			if pruned, pruneErr := eng.PruneAll(); pruneErr != nil {
+			var targetAgents []*agent.Agent
+			if len(agents) > 0 {
+				for _, name := range agents {
+					ag, err := reg.Get(name)
+					if err != nil {
+						return withExitCode(nd.ExitInvalidUsage,
+							fmt.Errorf("unknown agent %q; use 'nd doctor' to list available agents", name))
+					}
+					if !ag.Detected {
+						return withExitCode(nd.ExitInvalidUsage,
+							fmt.Errorf("agent %q is not detected on this system", name))
+					}
+					targetAgents = append(targetAgents, ag)
+				}
+			} else {
+				sm, smErr := app.SourceManager()
+				if smErr == nil {
+					cfg := sm.Config()
+					if len(cfg.DefaultDeployAgents) > 0 {
+						for _, name := range cfg.DefaultDeployAgents {
+							ag, err := reg.Get(name)
+							if err == nil && ag.Detected {
+								targetAgents = append(targetAgents, ag)
+							}
+						}
+					}
+				}
+			}
+
+			// Fall back to single active agent if no multi-agent targets resolved
+			if len(targetAgents) == 0 {
+				ag, err := app.ActiveAgent()
+				if err != nil {
+					return err
+				}
+				targetAgents = []*agent.Agent{ag}
+			}
+
+			// Prune via first agent engine (best-effort pre-op cleanup)
+			firstEng, err := app.DeployEngineFor(targetAgents[0])
+			if err != nil {
+				return err
+			}
+			if pruned, pruneErr := firstEng.PruneAll(); pruneErr != nil {
 				if !app.Quiet {
 					printHuman(cmd.ErrOrStderr(), "warning: prune failed: %v\n", pruneErr)
 				}
@@ -124,25 +170,40 @@ Asset references can be:
 				printHuman(cmd.ErrOrStderr(), "Pruned %d stale deployment(s)\n", pruned)
 			}
 
+			multiAgent := len(targetAgents) > 1
+
 			if app.DryRun {
 				if app.JSON {
 					type dryRunEntry struct {
 						AssetType string `json:"asset_type"`
 						AssetName string `json:"asset_name"`
 						Source    string `json:"source"`
+						Agent     string `json:"agent,omitempty"`
 					}
-					entries := make([]dryRunEntry, len(assets))
-					for i, a := range assets {
-						entries[i] = dryRunEntry{
-							AssetType: string(a.Type),
-							AssetName: a.Name,
-							Source:    a.SourceID,
+					var entries []dryRunEntry
+					for _, ag := range targetAgents {
+						for _, a := range assets {
+							e := dryRunEntry{
+								AssetType: string(a.Type),
+								AssetName: a.Name,
+								Source:    a.SourceID,
+							}
+							if multiAgent {
+								e.Agent = ag.Name
+							}
+							entries = append(entries, e)
 						}
 					}
 					return printJSON(w, entries, true)
 				}
-				for _, a := range assets {
-					printHuman(w, "[dry-run] would deploy %s/%s from %s\n", a.Type, a.Name, a.SourceID)
+				for _, ag := range targetAgents {
+					for _, a := range assets {
+						if multiAgent {
+							printHuman(w, "[dry-run] would deploy %s/%s from %s -> %s\n", a.Type, a.Name, a.SourceID, ag.Name)
+						} else {
+							printHuman(w, "[dry-run] would deploy %s/%s from %s\n", a.Type, a.Name, a.SourceID)
+						}
+					}
 				}
 				return nil
 			}
@@ -173,31 +234,43 @@ Asset references can be:
 				}
 			}
 
-			if len(reqs) == 1 {
-				result, err := eng.Deploy(reqs[0])
+			// Deploy to each target agent
+			var allSucceeded []deploy.DeployResult
+			var allFailed []deploy.DeployError
+			for _, ag := range targetAgents {
+				eng, err := app.DeployEngineFor(ag)
 				if err != nil {
 					return err
 				}
-				app.LogOp(oplog.LogEntry{
-					Timestamp: time.Now(),
-					Operation: oplog.OpDeploy,
-					Assets:    []asset.Identity{reqs[0].Asset.Identity},
-					Scope:     app.Scope,
-					Succeeded: 1,
-				})
-				if app.JSON {
-					return printJSON(w, result, false)
-				}
-				if !app.Quiet {
-					printHuman(w, "Deployed %s/%s\n", reqs[0].Asset.Type, reqs[0].Asset.Name)
-					printSettingsReminder(w, reqs[0].Asset.Type)
-				}
-				return nil
-			}
 
-			bulkResult, err := eng.DeployBulk(reqs)
-			if err != nil {
-				return err
+				if len(reqs) == 1 && len(targetAgents) == 1 {
+					result, err := eng.Deploy(reqs[0])
+					if err != nil {
+						return err
+					}
+					app.LogOp(oplog.LogEntry{
+						Timestamp: time.Now(),
+						Operation: oplog.OpDeploy,
+						Assets:    []asset.Identity{reqs[0].Asset.Identity},
+						Scope:     app.Scope,
+						Succeeded: 1,
+					})
+					if app.JSON {
+						return printJSON(w, result, false)
+					}
+					if !app.Quiet {
+						printHuman(w, "Deployed %s/%s\n", reqs[0].Asset.Type, reqs[0].Asset.Name)
+						printSettingsReminder(w, reqs[0].Asset.Type)
+					}
+					return nil
+				}
+
+				bulkResult, err := eng.DeployBulk(reqs)
+				if err != nil {
+					return err
+				}
+				allSucceeded = append(allSucceeded, bulkResult.Succeeded...)
+				allFailed = append(allFailed, bulkResult.Failed...)
 			}
 
 			var logAssets []asset.Identity
@@ -209,20 +282,27 @@ Asset references can be:
 				Operation: oplog.OpDeploy,
 				Assets:    logAssets,
 				Scope:     app.Scope,
-				Succeeded: len(bulkResult.Succeeded),
-				Failed:    len(bulkResult.Failed),
+				Succeeded: len(allSucceeded),
+				Failed:    len(allFailed),
 			})
 
 			if app.JSON {
-				return printJSON(w, bulkResult, false)
+				return printJSON(w, deploy.BulkDeployResult{
+					Succeeded: allSucceeded,
+					Failed:    allFailed,
+				}, false)
 			}
 
 			if !app.Quiet {
-				for _, s := range bulkResult.Succeeded {
-					printHuman(w, "Deployed %s/%s\n", s.Deployment.AssetType, s.Deployment.AssetName)
+				for _, s := range allSucceeded {
+					if multiAgent && s.Deployment.Agent != "" {
+						printHuman(w, "Deployed %s/%s -> %s\n", s.Deployment.AssetType, s.Deployment.AssetName, s.Deployment.Agent)
+					} else {
+						printHuman(w, "Deployed %s/%s\n", s.Deployment.AssetType, s.Deployment.AssetName)
+					}
 				}
 				unsupported := 0
-				for _, f := range bulkResult.Failed {
+				for _, f := range allFailed {
 					if f.UnsupportedType {
 						unsupported++
 						continue
@@ -230,16 +310,14 @@ Asset references can be:
 					printHuman(cmd.ErrOrStderr(), "Failed: %s/%s: %v\n", f.AssetType, f.AssetName, f.Err)
 				}
 				if unsupported > 0 {
-					ag, _ := app.ActiveAgent()
-					name := "unknown"
-					if ag != nil {
-						name = ag.Name
+					var agentNames []string
+					for _, ag := range targetAgents {
+						agentNames = append(agentNames, ag.Name)
 					}
-					printHuman(cmd.ErrOrStderr(), "Skipped %d asset(s) (unsupported by agent %s)\n", unsupported, name)
+					printHuman(cmd.ErrOrStderr(), "Skipped %d asset(s) (unsupported by agent(s) %s)\n", unsupported, strings.Join(agentNames, ", "))
 				}
-				// Print settings reminder once if any deployed type needs it
 				settingsTypes := make(map[nd.AssetType]bool)
-				for _, s := range bulkResult.Succeeded {
+				for _, s := range allSucceeded {
 					if s.Deployment.AssetType.RequiresSettingsRegistration() {
 						settingsTypes[s.Deployment.AssetType] = true
 					}
@@ -249,14 +327,15 @@ Asset references can be:
 				}
 			}
 
-			if len(bulkResult.Failed) > 0 {
+			if len(allFailed) > 0 {
 				if !app.Quiet {
 					if name := latestAutoSnapshot(app); name != "" {
 						printHuman(w, "Auto-snapshot saved. Restore with: nd snapshot restore %s\n", name)
 					}
 				}
+				totalReqs := len(reqs) * len(targetAgents)
 				return withExitCode(nd.ExitPartialFailure,
-					fmt.Errorf("%d of %d deployments failed", len(bulkResult.Failed), len(reqs)))
+					fmt.Errorf("%d of %d deployments failed", len(allFailed), totalReqs))
 			}
 			return nil
 		},
@@ -287,6 +366,10 @@ Asset references can be:
 			types = append(types, string(t))
 		}
 		return types, cobra.ShellCompDirectiveNoFileComp
+	})
+	cmd.Flags().StringSliceVar(&agents, "agents", nil, "comma-separated target agents (overrides config default_deploy_agents)")
+	cmd.RegisterFlagCompletionFunc("agents", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return agent.KnownAgentNames(), cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.Flags().BoolVar(&relative, "relative", false, "use relative symlinks (overrides config)")
 	cmd.Flags().BoolVar(&absolute, "absolute", false, "use absolute symlinks (overrides config)")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -122,6 +122,7 @@ Asset references can be:
 			var targetAgents []*agent.Agent
 			if len(agents) > 0 {
 				for _, name := range agents {
+					name = strings.TrimSpace(name)
 					ag, err := reg.Get(name)
 					if err != nil {
 						return withExitCode(nd.ExitInvalidUsage,
@@ -267,10 +268,16 @@ Asset references can be:
 
 				bulkResult, err := eng.DeployBulk(reqs)
 				if err != nil {
-					return err
+					return fmt.Errorf("[%s] %w", ag.Name, err)
 				}
 				allSucceeded = append(allSucceeded, bulkResult.Succeeded...)
-				allFailed = append(allFailed, bulkResult.Failed...)
+				for _, f := range bulkResult.Failed {
+					f.Agent = ag.Name
+					if multiAgent && f.Err != nil {
+						f.Err = fmt.Errorf("[%s] %w", ag.Name, f.Err)
+					}
+					allFailed = append(allFailed, f)
+				}
 			}
 
 			var logAssets []asset.Identity

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -27,7 +27,7 @@ type Registry struct {
 
 // KnownAgentNames returns the names of all built-in agents.
 func KnownAgentNames() []string {
-	return []string{"claude-code", "copilot"}
+	return nd.KnownAgentNames()
 }
 
 // New creates a Registry with known agent definitions and applies config overrides.

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -25,6 +25,11 @@ type Registry struct {
 	runCommand func(name string, args ...string) ([]byte, error) // nil = skip binary verification
 }
 
+// KnownAgentNames returns the names of all built-in agents.
+func KnownAgentNames() []string {
+	return []string{"claude-code", "copilot"}
+}
+
 // New creates a Registry with known agent definitions and applies config overrides.
 func New(cfg config.Config) *Registry {
 	homeDir := "~"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,13 +6,14 @@ import "github.com/armstrongl/nd/internal/nd"
 // This is what the rest of the application uses after loading + merging.
 // Merge order: built-in defaults -> global config -> project config -> CLI flags.
 type Config struct {
-	Version         int                `yaml:"version"          json:"version"`
-	DefaultScope    nd.Scope           `yaml:"default_scope"    json:"default_scope"`
-	DefaultAgent    string             `yaml:"default_agent"    json:"default_agent"`
-	SymlinkStrategy nd.SymlinkStrategy `yaml:"symlink_strategy" json:"symlink_strategy"`
-	Sources         []SourceEntry      `yaml:"sources"          json:"sources"`
-	Agents          []AgentOverride    `yaml:"agents,omitempty" json:"agents,omitempty"`
-	ContextTypes    []string           `yaml:"context_types,omitempty" json:"context_types,omitempty"`
+	Version             int                `yaml:"version"                        json:"version"`
+	DefaultScope        nd.Scope           `yaml:"default_scope"                  json:"default_scope"`
+	DefaultAgent        string             `yaml:"default_agent"                  json:"default_agent"`
+	DefaultDeployAgents []string           `yaml:"default_deploy_agents,omitempty" json:"default_deploy_agents,omitempty"`
+	SymlinkStrategy     nd.SymlinkStrategy `yaml:"symlink_strategy"               json:"symlink_strategy"`
+	Sources             []SourceEntry      `yaml:"sources"                        json:"sources"`
+	Agents              []AgentOverride    `yaml:"agents,omitempty"               json:"agents,omitempty"`
+	ContextTypes        []string           `yaml:"context_types,omitempty"        json:"context_types,omitempty"`
 }
 
 // SourceEntry represents a source registration in the config file.
@@ -37,10 +38,11 @@ type AgentOverride struct {
 // Fields are pointers so we can distinguish "not set" from "set to zero value"
 // during the merge with global config.
 type ProjectConfig struct {
-	Version         int                 `yaml:"version"`
-	DefaultScope    *nd.Scope           `yaml:"default_scope,omitempty"`
-	DefaultAgent    *string             `yaml:"default_agent,omitempty"`
-	SymlinkStrategy *nd.SymlinkStrategy `yaml:"symlink_strategy,omitempty"`
-	Sources         []SourceEntry       `yaml:"sources,omitempty"`
-	Agents          []AgentOverride     `yaml:"agents,omitempty"`
+	Version             int                 `yaml:"version"`
+	DefaultScope        *nd.Scope           `yaml:"default_scope,omitempty"`
+	DefaultAgent        *string             `yaml:"default_agent,omitempty"`
+	DefaultDeployAgents []string            `yaml:"default_deploy_agents,omitempty"`
+	SymlinkStrategy     *nd.SymlinkStrategy `yaml:"symlink_strategy,omitempty"`
+	Sources             []SourceEntry       `yaml:"sources,omitempty"`
+	Agents              []AgentOverride     `yaml:"agents,omitempty"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,6 +173,92 @@ func TestValidationErrorImplementsError(t *testing.T) {
 	}
 }
 
+func TestConfigDefaultDeployAgentsRoundTrip(t *testing.T) {
+	c := config.Config{
+		Version:             1,
+		DefaultScope:        nd.ScopeGlobal,
+		DefaultAgent:        "claude-code",
+		DefaultDeployAgents: []string{"claude-code", "copilot"},
+		SymlinkStrategy:     nd.SymlinkAbsolute,
+		Sources:             []config.SourceEntry{},
+	}
+
+	data, err := yaml.Marshal(&c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got config.Config
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(got.DefaultDeployAgents) != 2 {
+		t.Fatalf("default_deploy_agents: got %d, want 2", len(got.DefaultDeployAgents))
+	}
+	if got.DefaultDeployAgents[0] != "claude-code" || got.DefaultDeployAgents[1] != "copilot" {
+		t.Errorf("default_deploy_agents: got %v", got.DefaultDeployAgents)
+	}
+}
+
+func TestConfigDefaultDeployAgentsOmittedWhenEmpty(t *testing.T) {
+	c := config.Config{
+		Version:         1,
+		DefaultScope:    nd.ScopeGlobal,
+		DefaultAgent:    "claude-code",
+		SymlinkStrategy: nd.SymlinkAbsolute,
+		Sources:         []config.SourceEntry{},
+	}
+
+	data, err := yaml.Marshal(&c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if contains(string(data), "default_deploy_agents") {
+		t.Error("empty default_deploy_agents should not appear in YAML")
+	}
+}
+
+func TestConfigValidateDefaultDeployAgentsValid(t *testing.T) {
+	c := config.Config{
+		Version:             1,
+		DefaultScope:        nd.ScopeGlobal,
+		DefaultAgent:        "claude-code",
+		DefaultDeployAgents: []string{"claude-code", "copilot"},
+		SymlinkStrategy:     nd.SymlinkAbsolute,
+	}
+	errs := c.Validate()
+	for _, e := range errs {
+		if e.Field == "default_deploy_agents" {
+			t.Errorf("unexpected validation error: %v", e)
+		}
+	}
+}
+
+func TestConfigValidateDefaultDeployAgentsUnknown(t *testing.T) {
+	c := config.Config{
+		Version:             1,
+		DefaultScope:        nd.ScopeGlobal,
+		DefaultAgent:        "claude-code",
+		DefaultDeployAgents: []string{"claude-code", "bogus-agent"},
+		SymlinkStrategy:     nd.SymlinkAbsolute,
+	}
+	errs := c.Validate()
+	found := false
+	for _, e := range errs {
+		if e.Field == "default_deploy_agents" {
+			found = true
+			if !contains(e.Message, "bogus-agent") {
+				t.Errorf("error message should mention bogus-agent: %s", e.Message)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected validation error for unknown agent name")
+	}
+}
+
 func TestConfigValidateInvalidSourceType(t *testing.T) {
 	c := config.Config{
 		Version:         1,

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -55,7 +55,10 @@ func (c *Config) Validate() []ValidationError {
 		})
 	}
 
-	knownAgents := map[string]bool{"claude-code": true, "copilot": true}
+	knownAgents := make(map[string]bool, len(nd.KnownAgentNames()))
+	for _, n := range nd.KnownAgentNames() {
+		knownAgents[n] = true
+	}
 	for _, name := range c.DefaultDeployAgents {
 		if !knownAgents[name] {
 			errs = append(errs, ValidationError{

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -55,6 +55,16 @@ func (c *Config) Validate() []ValidationError {
 		})
 	}
 
+	knownAgents := map[string]bool{"claude-code": true, "copilot": true}
+	for _, name := range c.DefaultDeployAgents {
+		if !knownAgents[name] {
+			errs = append(errs, ValidationError{
+				Field:   "default_deploy_agents",
+				Message: fmt.Sprintf("unknown agent %q", name),
+			})
+		}
+	}
+
 	switch c.SymlinkStrategy {
 	case nd.SymlinkAbsolute, nd.SymlinkRelative:
 		// valid

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -129,6 +129,7 @@ type DeployError struct {
 	AssetName       string
 	AssetType       nd.AssetType
 	SourcePath      string
+	Agent           string // target agent name (populated in multi-agent deploys)
 	Err             error
 	UnsupportedType bool // true when the failure is due to agent type incompatibility
 }

--- a/internal/nd/agents.go
+++ b/internal/nd/agents.go
@@ -1,0 +1,6 @@
+package nd
+
+// KnownAgentNames returns the names of all built-in agents.
+func KnownAgentNames() []string {
+	return []string{"claude-code", "copilot"}
+}

--- a/internal/sourcemanager/config.go
+++ b/internal/sourcemanager/config.go
@@ -88,6 +88,9 @@ func MergeConfigs(global config.Config, project *config.ProjectConfig) config.Co
 	if project.DefaultAgent != nil {
 		merged.DefaultAgent = *project.DefaultAgent
 	}
+	if len(project.DefaultDeployAgents) > 0 {
+		merged.DefaultDeployAgents = project.DefaultDeployAgents
+	}
 	if project.SymlinkStrategy != nil {
 		merged.SymlinkStrategy = *project.SymlinkStrategy
 	}

--- a/internal/sourcemanager/config_test.go
+++ b/internal/sourcemanager/config_test.go
@@ -193,6 +193,36 @@ func TestMergeConfigsAgentOverrides(t *testing.T) {
 	}
 }
 
+func TestMergeConfigsDefaultDeployAgentsFromProject(t *testing.T) {
+	global := sourcemanager.DefaultConfig()
+	global.DefaultDeployAgents = []string{"claude-code"}
+
+	project := config.ProjectConfig{
+		Version:             1,
+		DefaultDeployAgents: []string{"claude-code", "copilot"},
+	}
+
+	merged := sourcemanager.MergeConfigs(global, &project)
+	if len(merged.DefaultDeployAgents) != 2 {
+		t.Fatalf("expected 2 deploy agents, got %d", len(merged.DefaultDeployAgents))
+	}
+	if merged.DefaultDeployAgents[0] != "claude-code" || merged.DefaultDeployAgents[1] != "copilot" {
+		t.Errorf("deploy agents: got %v", merged.DefaultDeployAgents)
+	}
+}
+
+func TestMergeConfigsDefaultDeployAgentsPreservedWhenProjectEmpty(t *testing.T) {
+	global := sourcemanager.DefaultConfig()
+	global.DefaultDeployAgents = []string{"claude-code"}
+
+	project := config.ProjectConfig{Version: 1}
+
+	merged := sourcemanager.MergeConfigs(global, &project)
+	if len(merged.DefaultDeployAgents) != 1 || merged.DefaultDeployAgents[0] != "claude-code" {
+		t.Errorf("expected global deploy agents preserved, got %v", merged.DefaultDeployAgents)
+	}
+}
+
 func TestWriteConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/tui/deploy.go
+++ b/internal/tui/deploy.go
@@ -482,7 +482,23 @@ func (ds *deployScreen) updatePickAgents(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if ds.agentForm.State == huh.StateCompleted {
 		if len(ds.selectedAgents) == 0 {
-			return ds, func() tea.Msg { return BackMsg{} }
+			// Reject empty selection: rebuild the form and stay on the picker
+			reg, err := ds.svc.AgentRegistry()
+			if err != nil {
+				return ds, nil
+			}
+			reg.Detect()
+			var detected []*agent.Agent
+			for _, a := range reg.All() {
+				if a.Detected {
+					ag, _ := reg.Get(a.Name)
+					if ag != nil {
+						detected = append(detected, ag)
+					}
+				}
+			}
+			ds.buildAgentForm(detected)
+			return ds, ds.agentForm.Init()
 		}
 		reg, err := ds.svc.AgentRegistry()
 		if err != nil {
@@ -614,11 +630,11 @@ func (ds *deployScreen) startDeploy() tea.Cmd {
 	ds.progress = newProgressBar(40)
 
 	// Multi-agent deploy: build per-agent request sets and deploy each
-	if len(ds.targetAgents) > 1 {
+	if len(ds.targetAgents) > 0 {
 		return ds.multiAgentDeployCmd(reqs)
 	}
 
-	// Single-agent path (existing behavior)
+	// Fallback: no target agents resolved, use active agent engine
 	eng, err := ds.svc.DeployEngine()
 	if err != nil {
 		ds.err = fmt.Errorf("deploy engine: %w", err)
@@ -684,13 +700,20 @@ func (ds *deployScreen) multiAgentDeployCmd(reqs []deploy.DeployRequest) tea.Cmd
 						AssetName:  req.Asset.Name,
 						AssetType:  req.Asset.Type,
 						SourcePath: req.Asset.SourcePath,
-						Err:        err,
+						Agent:      ag.Name,
+						Err:        fmt.Errorf("[%s] %w", ag.Name, err),
 					})
 				}
 				continue
 			}
 			allSucceeded = append(allSucceeded, result.Succeeded...)
-			allFailed = append(allFailed, result.Failed...)
+			for _, f := range result.Failed {
+				f.Agent = ag.Name
+				if f.Err != nil {
+					f.Err = fmt.Errorf("[%s] %w", ag.Name, f.Err)
+				}
+				allFailed = append(allFailed, f)
+			}
 		}
 
 		return deployDoneMsg{succeeded: allSucceeded, failed: allFailed}
@@ -846,7 +869,7 @@ func (ds *deployScreen) updateConflictConfirm(msg tea.Msg) (tea.Model, tea.Cmd) 
 		}
 		// User said replace: re-run with ForceReplace=true.
 		ds.step = deployRunning
-		if len(ds.targetAgents) > 1 {
+		if len(ds.targetAgents) > 0 {
 			return ds, ds.multiAgentDeployCmd(ds.conflictReqs)
 		}
 		eng, err := ds.svc.DeployEngine()

--- a/internal/tui/deploy.go
+++ b/internal/tui/deploy.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
 
+	"github.com/armstrongl/nd/internal/agent"
 	"github.com/armstrongl/nd/internal/asset"
 	"github.com/armstrongl/nd/internal/deploy"
 	"github.com/armstrongl/nd/internal/nd"
@@ -20,6 +21,7 @@ type deployStep int
 
 const (
 	deployPickType deployStep = iota
+	deployPickAgents
 	deploySelectAssets
 	deployRunning
 	deployConflictConfirm
@@ -58,6 +60,11 @@ type deployScreen struct {
 	typeForm   *huh.Form
 	typeChoice string
 	scanning   bool // H1: guards against double-fire after type form completion
+
+	// pickAgents step
+	agentForm      *huh.Form
+	selectedAgents []string       // agent names chosen by user
+	targetAgents   []*agent.Agent // resolved agents for deploy
 
 	// selectAssets step
 	assetForm *huh.Form
@@ -135,7 +142,7 @@ func newDeployScreen(svc Services, styles Styles, isDark bool) *deployScreen {
 func (ds *deployScreen) Title() string { return "Deploy" }
 
 func (ds *deployScreen) InputActive() bool {
-	return ds.step == deployPickType || ds.step == deploySelectAssets || ds.step == deployConflictConfirm
+	return ds.step == deployPickType || ds.step == deployPickAgents || ds.step == deploySelectAssets || ds.step == deployConflictConfirm
 }
 
 // FullHelpItems returns step-specific help items for the deploy screen.
@@ -147,6 +154,14 @@ func (ds *deployScreen) FullHelpItems() []HelpItem {
 			{"esc", "back"},
 			{"j/k", "navigate"},
 			{"enter", "select"},
+			{"q", "quit"},
+		}
+	case deployPickAgents:
+		return []HelpItem{
+			{"esc", "back"},
+			{"j/k", "navigate"},
+			{"x/space", "toggle"},
+			{"enter", "confirm"},
 			{"q", "quit"},
 		}
 	case deploySelectAssets:
@@ -248,6 +263,8 @@ func (ds *deployScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch ds.step {
 	case deployPickType:
 		return ds.updatePickType(msg)
+	case deployPickAgents:
+		return ds.updatePickAgents(msg)
 	case deploySelectAssets:
 		return ds.updateSelectAssets(msg)
 	case deployConflictConfirm:
@@ -276,6 +293,12 @@ func (ds *deployScreen) View() tea.View {
 	switch ds.step {
 	case deployPickType:
 		return tea.NewView(ds.typeForm.View())
+
+	case deployPickAgents:
+		if ds.agentForm != nil {
+			return tea.NewView(ds.agentForm.View())
+		}
+		return tea.NewView("  Loading agents...")
 
 	case deploySelectAssets:
 		if ds.assetForm != nil {
@@ -315,7 +338,7 @@ func (ds *deployScreen) updatePickType(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if ds.typeForm.State == huh.StateCompleted {
 		ds.scanning = true
-		return ds, ds.startScan()
+		return ds.resolveAgentsAndAdvance()
 	}
 
 	if ds.typeForm.State == huh.StateAborted {
@@ -372,6 +395,117 @@ func (ds *deployScreen) startScan() tea.Cmd {
 		undeployed := filterUndeployed(deployable, deployed)
 		return scanDoneMsg{assets: undeployed}
 	}
+}
+
+// resolveAgentsAndAdvance determines target agents after type selection.
+// If default_deploy_agents is configured, uses those; if only one agent is
+// detected, uses it; otherwise shows the multi-select agent picker.
+func (ds *deployScreen) resolveAgentsAndAdvance() (tea.Model, tea.Cmd) {
+	reg, err := ds.svc.AgentRegistry()
+	if err != nil || reg == nil {
+		ds.targetAgents = nil
+		return ds, ds.startScan()
+	}
+	reg.Detect()
+
+	// Check config for default_deploy_agents
+	if sm, err := ds.svc.SourceManager(); err == nil && sm != nil {
+		cfg := sm.Config()
+		if len(cfg.DefaultDeployAgents) > 0 {
+			var agents []*agent.Agent
+			for _, name := range cfg.DefaultDeployAgents {
+				ag, err := reg.Get(name)
+				if err == nil && ag.Detected {
+					agents = append(agents, ag)
+				}
+			}
+			if len(agents) > 0 {
+				ds.targetAgents = agents
+				return ds, ds.startScan()
+			}
+		}
+	}
+
+	// Count detected agents
+	var detected []*agent.Agent
+	for _, a := range reg.All() {
+		if a.Detected {
+			ac := a
+			ag, _ := reg.Get(ac.Name)
+			if ag != nil {
+				detected = append(detected, ag)
+			}
+		}
+	}
+
+	if len(detected) <= 1 {
+		ds.targetAgents = detected
+		return ds, ds.startScan()
+	}
+
+	// Multiple detected agents — show picker
+	ds.step = deployPickAgents
+	ds.buildAgentForm(detected)
+	return ds, ds.agentForm.Init()
+}
+
+// buildAgentForm creates the multi-select agent picker form.
+func (ds *deployScreen) buildAgentForm(detected []*agent.Agent) {
+	opts := make([]huh.Option[string], len(detected))
+	for i, a := range detected {
+		opts[i] = huh.NewOption(a.Name, a.Name)
+	}
+
+	ds.agentForm = huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select target agents").
+				Options(opts...).
+				Value(&ds.selectedAgents),
+		),
+	).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin))
+}
+
+// updatePickAgents handles input at the agent picker step.
+func (ds *deployScreen) updatePickAgents(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && keyMsg.String() == "esc" {
+		return ds, func() tea.Msg { return BackMsg{} }
+	}
+	if ds.agentForm == nil {
+		return ds, nil
+	}
+
+	model, cmd := ds.agentForm.Update(msg)
+	if f, ok := model.(*huh.Form); ok {
+		ds.agentForm = f
+	}
+
+	if ds.agentForm.State == huh.StateCompleted {
+		if len(ds.selectedAgents) == 0 {
+			return ds, func() tea.Msg { return BackMsg{} }
+		}
+		reg, err := ds.svc.AgentRegistry()
+		if err != nil {
+			ds.err = fmt.Errorf("agent registry: %w", err)
+			ds.step = deployResult
+			return ds, nil
+		}
+		var agents []*agent.Agent
+		for _, name := range ds.selectedAgents {
+			ag, err := reg.Get(name)
+			if err == nil {
+				agents = append(agents, ag)
+			}
+		}
+		ds.targetAgents = agents
+		return ds, ds.startScan()
+	}
+
+	if ds.agentForm.State == huh.StateAborted {
+		return ds, func() tea.Msg { return BackMsg{} }
+	}
+
+	return ds, cmd
 }
 
 // buildAssetForm creates the multi-select form from the available (undeployed) assets.
@@ -479,6 +613,12 @@ func (ds *deployScreen) startDeploy() tea.Cmd {
 	ds.step = deployRunning
 	ds.progress = newProgressBar(40)
 
+	// Multi-agent deploy: build per-agent request sets and deploy each
+	if len(ds.targetAgents) > 1 {
+		return ds.multiAgentDeployCmd(reqs)
+	}
+
+	// Single-agent path (existing behavior)
 	eng, err := ds.svc.DeployEngine()
 	if err != nil {
 		ds.err = fmt.Errorf("deploy engine: %w", err)
@@ -514,6 +654,49 @@ func deployBulkCmd(deployer func([]deploy.DeployRequest) (*deploy.BulkDeployResu
 	}
 }
 
+// multiAgentDeployCmd creates a tea.Cmd that deploys requests through multiple agent engines.
+func (ds *deployScreen) multiAgentDeployCmd(reqs []deploy.DeployRequest) tea.Cmd {
+	svc := ds.svc
+	agents := ds.targetAgents
+
+	return func() tea.Msg {
+		var allSucceeded []deploy.DeployResult
+		var allFailed []deploy.DeployError
+
+		for _, ag := range agents {
+			eng, err := svc.DeployEngineFor(ag)
+			if err != nil {
+				for _, req := range reqs {
+					allFailed = append(allFailed, deploy.DeployError{
+						AssetName:  req.Asset.Name,
+						AssetType:  req.Asset.Type,
+						SourcePath: req.Asset.SourcePath,
+						Err:        fmt.Errorf("engine for %s: %w", ag.Name, err),
+					})
+				}
+				continue
+			}
+
+			result, err := eng.DeployBulk(reqs)
+			if err != nil {
+				for _, req := range reqs {
+					allFailed = append(allFailed, deploy.DeployError{
+						AssetName:  req.Asset.Name,
+						AssetType:  req.Asset.Type,
+						SourcePath: req.Asset.SourcePath,
+						Err:        err,
+					})
+				}
+				continue
+			}
+			allSucceeded = append(allSucceeded, result.Succeeded...)
+			allFailed = append(allFailed, result.Failed...)
+		}
+
+		return deployDoneMsg{succeeded: allSucceeded, failed: allFailed}
+	}
+}
+
 // updateResult handles key presses at the result step.
 // H4: Only "enter" reaches here — esc/q are intercepted by root model.
 func (ds *deployScreen) updateResult(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -544,8 +727,14 @@ func (ds *deployScreen) buildResultContent() string {
 
 	// H2: Dry-run preview
 	if ds.dryRun {
-		fmt.Fprintf(&b, "  %s Would deploy %d asset(s):\n\n",
-			ds.styles.Warning.Render("[DRY RUN]"), len(ds.dryReqs))
+		agentNames := ds.targetAgentNames()
+		if len(agentNames) > 0 {
+			fmt.Fprintf(&b, "  %s Would deploy %d asset(s) to %s:\n\n",
+				ds.styles.Warning.Render("[DRY RUN]"), len(ds.dryReqs), strings.Join(agentNames, ", "))
+		} else {
+			fmt.Fprintf(&b, "  %s Would deploy %d asset(s):\n\n",
+				ds.styles.Warning.Render("[DRY RUN]"), len(ds.dryReqs))
+		}
 		for _, req := range ds.dryReqs {
 			fmt.Fprintf(&b, "    %s %s/%s from %s\n",
 				GlyphArrow, req.Asset.Type, req.Asset.Name, req.Asset.SourceID)
@@ -558,12 +747,19 @@ func (ds *deployScreen) buildResultContent() string {
 	total := len(ds.succeeded) + len(ds.failed)
 	fmt.Fprintf(&b, "  Deployment complete: %d of %d succeeded\n\n", len(ds.succeeded), total)
 
+	multiAgent := len(ds.targetAgents) > 1
+
 	if len(ds.succeeded) > 0 {
 		fmt.Fprintf(&b, "  %s\n", ds.styles.Success.Render(
 			fmt.Sprintf("%d succeeded", len(ds.succeeded))))
 		for _, r := range ds.succeeded {
-			fmt.Fprintf(&b, "    %s %s/%s\n",
-				GlyphOK, r.Deployment.AssetType, r.Deployment.AssetName)
+			if multiAgent && r.Deployment.Agent != "" {
+				fmt.Fprintf(&b, "    %s %s/%s -> %s\n",
+					GlyphOK, r.Deployment.AssetType, r.Deployment.AssetName, r.Deployment.Agent)
+			} else {
+				fmt.Fprintf(&b, "    %s %s/%s\n",
+					GlyphOK, r.Deployment.AssetType, r.Deployment.AssetName)
+			}
 		}
 		b.WriteString("\n")
 	}
@@ -650,6 +846,9 @@ func (ds *deployScreen) updateConflictConfirm(msg tea.Msg) (tea.Model, tea.Cmd) 
 		}
 		// User said replace: re-run with ForceReplace=true.
 		ds.step = deployRunning
+		if len(ds.targetAgents) > 1 {
+			return ds, ds.multiAgentDeployCmd(ds.conflictReqs)
+		}
 		eng, err := ds.svc.DeployEngine()
 		if err != nil || eng == nil {
 			ds.err = fmt.Errorf("deploy engine not available")
@@ -719,6 +918,15 @@ func assetKey(a *asset.Asset) string {
 // deploymentKey returns a unique key for a deployment: "sourceID:type/name".
 func deploymentKey(d state.Deployment) string {
 	return fmt.Sprintf("%s:%s/%s", d.SourceID, d.AssetType, d.AssetName)
+}
+
+// targetAgentNames returns the names of the selected target agents.
+func (ds *deployScreen) targetAgentNames() []string {
+	names := make([]string, len(ds.targetAgents))
+	for i, a := range ds.targetAgents {
+		names[i] = a.Name
+	}
+	return names
 }
 
 // filterUndeployed returns only assets that are not already deployed.

--- a/internal/tui/deploy_test.go
+++ b/internal/tui/deploy_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/armstrongl/nd/internal/agent"
 	"github.com/armstrongl/nd/internal/asset"
 	"github.com/armstrongl/nd/internal/deploy"
 	"github.com/armstrongl/nd/internal/nd"
@@ -643,6 +644,78 @@ func TestDeploy_FullHelpItems_Result(t *testing.T) {
 	}
 	if !hasEnterReturn {
 		t.Errorf("FullHelpItems at result should include 'enter return'; got: %v", items)
+	}
+}
+
+func TestDeploy_InputActive_PickAgents(t *testing.T) {
+	ds := newTestDeployScreen(deployPickAgents)
+	if !ds.InputActive() {
+		t.Fatal("InputActive() at pickAgents step should be true")
+	}
+}
+
+func TestDeploy_FullHelpItems_PickAgents(t *testing.T) {
+	ds := newTestDeployScreen(deployPickAgents)
+	items := ds.FullHelpItems()
+
+	hasToggle := false
+	for _, item := range items {
+		if item.Key == "x/space" && item.Desc == "toggle" {
+			hasToggle = true
+		}
+	}
+	if !hasToggle {
+		t.Errorf("FullHelpItems at pickAgents should include 'x/space toggle'; got: %v", items)
+	}
+}
+
+func TestDeploy_ResultView_ShowsAgentForMultiAgent(t *testing.T) {
+	ds := newTestDeployScreen(deployResult)
+	ds.targetAgents = []*agent.Agent{
+		{Name: "claude-code"},
+		{Name: "copilot"},
+	}
+	ds.succeeded = []deploy.DeployResult{
+		{Deployment: state.Deployment{AssetName: "go-test", AssetType: nd.AssetSkill, Agent: "claude-code"}},
+		{Deployment: state.Deployment{AssetName: "go-test", AssetType: nd.AssetSkill, Agent: "copilot"}},
+	}
+	ds.failed = nil
+
+	v := ds.View()
+	content := v.Content
+
+	if !strings.Contains(content, "-> claude-code") {
+		t.Errorf("result view should show '-> claude-code'; got:\n%s", content)
+	}
+	if !strings.Contains(content, "-> copilot") {
+		t.Errorf("result view should show '-> copilot'; got:\n%s", content)
+	}
+}
+
+func TestDeploy_ResultView_NoAgentForSingleAgent(t *testing.T) {
+	ds := newTestDeployScreen(deployResult)
+	ds.targetAgents = []*agent.Agent{{Name: "claude-code"}}
+	ds.succeeded = []deploy.DeployResult{
+		{Deployment: state.Deployment{AssetName: "go-test", AssetType: nd.AssetSkill, Agent: "claude-code"}},
+	}
+	ds.failed = nil
+
+	v := ds.View()
+	if strings.Contains(v.Content, "->") {
+		t.Errorf("single-agent result should not show agent arrow; got:\n%s", v.Content)
+	}
+}
+
+func TestDeploy_TargetAgentNames(t *testing.T) {
+	ds := &deployScreen{
+		targetAgents: []*agent.Agent{
+			{Name: "claude-code"},
+			{Name: "copilot"},
+		},
+	}
+	names := ds.targetAgentNames()
+	if len(names) != 2 || names[0] != "claude-code" || names[1] != "copilot" {
+		t.Errorf("targetAgentNames = %v, want [claude-code copilot]", names)
 	}
 }
 

--- a/internal/tui/services.go
+++ b/internal/tui/services.go
@@ -24,6 +24,7 @@ type Services interface {
 
 	// Deployment
 	DeployEngine() (*deploy.Engine, error)
+	DeployEngineFor(ag *agent.Agent) (*deploy.Engine, error)
 	StateStore() *state.Store
 
 	// Profiles & snapshots

--- a/internal/tui/testutil_test.go
+++ b/internal/tui/testutil_test.go
@@ -14,12 +14,13 @@ import (
 // All methods return sensible zero values by default. Override individual
 // function fields to inject custom behavior in tests.
 type mockServices struct {
-	sourceManagerFn  func() (*sourcemanager.SourceManager, error)
-	scanIndexFn      func() (*sourcemanager.ScanSummary, error)
-	agentRegistryFn  func() (*agent.Registry, error)
-	defaultAgentFn   func() (*agent.Agent, error)
-	deployEngineFn   func() (*deploy.Engine, error)
-	stateStoreFn     func() *state.Store
+	sourceManagerFn    func() (*sourcemanager.SourceManager, error)
+	scanIndexFn        func() (*sourcemanager.ScanSummary, error)
+	agentRegistryFn    func() (*agent.Registry, error)
+	defaultAgentFn     func() (*agent.Agent, error)
+	deployEngineFn     func() (*deploy.Engine, error)
+	deployEngineForFn  func(ag *agent.Agent) (*deploy.Engine, error)
+	stateStoreFn       func() *state.Store
 	profileManagerFn func() (*profile.Manager, error)
 	profileStoreFn   func() (*profile.Store, error)
 	opLogFn          func() *oplog.Writer
@@ -73,6 +74,13 @@ func (m *mockServices) ActiveAgent() (*agent.Agent, error) {
 func (m *mockServices) DeployEngine() (*deploy.Engine, error) {
 	if m.deployEngineFn != nil {
 		return m.deployEngineFn()
+	}
+	return nil, nil
+}
+
+func (m *mockServices) DeployEngineFor(ag *agent.Agent) (*deploy.Engine, error) {
+	if m.deployEngineForFn != nil {
+		return m.deployEngineForFn(ag)
 	}
 	return nil, nil
 }

--- a/tasks/cli/ba5xah-select-deploy-agents.md
+++ b/tasks/cli/ba5xah-select-deploy-agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Let user select target agents for deploy"
 id: "ba5xah"
-status: in-progress
+status: completed
 priority: high
 type: feature
 tags: ["deploy", "multi-agent"]
@@ -39,6 +39,7 @@ context:
   - "internal/tui/deploy.go"
   - "internal/tui/services.go"
   - "internal/tui/testutil_test.go"
+completed_at: 2026-05-20
 ---
 
 ## Let user select target agents for deploy

--- a/tasks/cli/ba5xah-select-deploy-agents.md
+++ b/tasks/cli/ba5xah-select-deploy-agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Let user select target agents for deploy"
 id: "ba5xah"
-status: pending
+status: in-progress
 priority: high
 type: feature
 tags: ["deploy", "multi-agent"]
@@ -82,18 +82,18 @@ and wire the snapshot saver the same way `DeployEngine()` does
 
 ### Tasks
 
-- [ ] **Config field.** Add `DefaultDeployAgents []string` to `config.Config`
+- [x] **Config field.** Add `DefaultDeployAgents []string` to `config.Config`
   with tag `` `yaml:"default_deploy_agents,omitempty" json:"default_deploy_agents,omitempty"` ``
   in `internal/config/config.go:8-16` (alongside `DefaultAgent` at line 11).
   Add the matching pointer-free slice to `ProjectConfig`
   (`internal/config/config.go:39-46`): `DefaultDeployAgents []string` with
   `` `yaml:"default_deploy_agents,omitempty"` `` (slices use len>0 to detect
   "set", consistent with `Sources`/`Agents` there).
-- [ ] **Merge.** In `MergeConfigs` (`internal/sourcemanager/config.go:78-122`)
+- [x] **Merge.** In `MergeConfigs` (`internal/sourcemanager/config.go:78-122`)
   add: `if len(project.DefaultDeployAgents) > 0 { merged.DefaultDeployAgents = project.DefaultDeployAgents }`
   near the `project.DefaultAgent` block (lines 88-90). Leave `DefaultConfig`
   (`internal/sourcemanager/config.go:18-26`) unchanged (empty slice = no default).
-- [ ] **Validate names.** In `Config.Validate`
+- [x] **Validate names.** In `Config.Validate`
   (`internal/config/validation.go:26-101`) add a block after the
   `DefaultAgent` check (lines 52-56): for each name in
   `c.DefaultDeployAgents`, verify it is one of the known agent names.
@@ -106,13 +106,13 @@ and wire the snapshot saver the same way `DeployEngine()` does
   CLI/sourcemanager boundary if an import cycle would result. Emit a
   `ValidationError{Field: "default_deploy_agents", Message: ...}` for unknown
   names (mirror the existing error style at lines 52-56).
-- [ ] **Engine factory helper.** Add a helper on `*App` in `cmd/app.go`
+- [x] **Engine factory helper.** Add a helper on `*App` in `cmd/app.go`
   (next to `DeployEngine`, `cmd/app.go:95-114`), e.g.
   `func (a *App) DeployEngineFor(ag *agent.Agent) (*deploy.Engine, error)`:
   build `deploy.New(a.StateStore(), ag, a.BackupDir)` and attach the snapshot
   saver exactly as lines 104-110 do. Refactor `DeployEngine()` to delegate to
   it for `ActiveAgent()` so the wiring stays single-sourced.
-- [ ] **TUI: new picker step.** In `internal/tui/deploy.go`:
+- [x] **TUI: new picker step.** In `internal/tui/deploy.go`:
   - Add `deployPickAgents` to the `deployStep` enum
     (`internal/tui/deploy.go:21-27`) ordered **between** `deployPickType` and
     `deploySelectAssets`. Updating iota will renumber later constants — that is
@@ -147,7 +147,7 @@ and wire the snapshot saver the same way `DeployEngine()` does
     `huh.StateCompleted` store `ds.selectedAgents` and advance to the scan
     step; on `huh.StateAborted` or `esc` emit `BackMsg{}`; reject an empty
     selection (do not advance).
-- [ ] **TUI: multi-agent deploy.** In `startDeploy`
+- [x] **TUI: multi-agent deploy.** In `startDeploy`
   (`internal/tui/deploy.go:430-494`) the request loop at lines 454-468 builds
   `[]deploy.DeployRequest` for one agent. Resolve `ds.selectedAgents` to
   `[]*agent.Agent` via `reg.Get(name)` (`internal/agent/registry.go:176-183`).
@@ -160,7 +160,7 @@ and wire the snapshot saver the same way `DeployEngine()` does
   branch (`internal/tui/deploy.go:471-477`) and the bulk command
   `deployBulkCmd` (`internal/tui/deploy.go:497-515`) must be extended to carry
   the target agent name so results can be labeled per agent.
-- [ ] **Result rendering.** In `buildResultContent`
+- [x] **Result rendering.** In `buildResultContent`
   (`internal/tui/deploy.go:542-588`) the success/fail lines
   (lines 564-567, 574-577) print `type/name`. Append the target agent, e.g.
   `skill/foo -> claude-code`. Use `state.Deployment.Agent`
@@ -168,7 +168,7 @@ and wire the snapshot saver the same way `DeployEngine()` does
   entries thread the agent name through `deploy.DeployError` /
   `deployBulkCmd`. Apply the same to the dry-run branch
   (`internal/tui/deploy.go:546-555`).
-- [ ] **CLI `--agents` flag.** In `newDeployCmd`
+- [x] **CLI `--agents` flag.** In `newDeployCmd`
   (`cmd/deploy.go:15-295`) register `cmd.Flags().StringSliceVar(&agents,
   "agents", nil, "comma-separated target agents (overrides config default_deploy_agents)")`
   next to the existing flags (`cmd/deploy.go:283-293`). Resolution precedence:
@@ -183,16 +183,16 @@ and wire the snapshot saver the same way `DeployEngine()` does
   merge results before the existing reporting block (`cmd/deploy.go:198-261`).
   Add a `cmd.RegisterFlagCompletionFunc("agents", ...)` returning known agent
   names (analogous to the `type` completion at `cmd/deploy.go:284-290`).
-- [ ] **Unit tests — config:** in `internal/config/config_test.go` (follow the
+- [x] **Unit tests — config:** in `internal/config/config_test.go` (follow the
   YAML round-trip pattern at `internal/config/config_test.go:11-40`) assert
   `default_deploy_agents` round-trips; in `internal/config/validation_test.go`
   (or `config_test.go`) assert an unknown agent name yields a
   `ValidationError` with `Field == "default_deploy_agents"` and a valid set
   yields none.
-- [ ] **Unit tests — merge:** in `internal/sourcemanager/` assert
+- [x] **Unit tests — merge:** in `internal/sourcemanager/` assert
   `MergeConfigs` replaces `DefaultDeployAgents` from a non-empty project value
   and preserves the global value when the project slice is empty.
-- [ ] **TUI tests:** in `internal/tui/deploy_test.go` (use `newMockServices()`
+- [x] **TUI tests:** in `internal/tui/deploy_test.go` (use `newMockServices()`
   and the existing `newTestDeployScreen` helper at
   `internal/tui/deploy_test.go:50-69`; override `agentRegistryFn` /
   `defaultAgentFn` on the mock — see `internal/tui/testutil_test.go:59-71`):
@@ -200,7 +200,7 @@ and wire the snapshot saver the same way `DeployEngine()` does
   one agent is detected; picker is skipped and config agents used when
   `DefaultDeployAgents` is set; single-agent selection and two-agent selection
   both produce the correct per-agent request sets.
-- [ ] **Integration test:** add to `tests/integration/deploy_test.go` (use
+- [x] **Integration test:** add to `tests/integration/deploy_test.go` (use
   `setupIntegrationEnv` + `runND`, see `tests/integration/deploy_test.go:9-37`):
   `nd deploy --agents <name> greeting` succeeds and `nd deploy --agents bogus
   greeting` exits non-zero with a clear message. (Detection in the sandboxed

--- a/tests/integration/deploy_test.go
+++ b/tests/integration/deploy_test.go
@@ -69,6 +69,31 @@ func TestDeployJSON(t *testing.T) {
 	}
 }
 
+func TestDeployWithAgentsFlag(t *testing.T) {
+	configPath, _ := setupIntegrationEnv(t)
+
+	result := runND(t, "--config", configPath, "deploy", "--agents", "claude-code", "greeting")
+	if result.ExitCode != 0 {
+		t.Fatalf("deploy --agents exit code %d, stderr: %s", result.ExitCode, result.Stderr)
+	}
+	if !strings.Contains(result.Stdout, "Deployed") {
+		t.Errorf("expected 'Deployed' in output, got: %s", result.Stdout)
+	}
+}
+
+func TestDeployWithAgentsFlagBogus(t *testing.T) {
+	configPath, _ := setupIntegrationEnv(t)
+
+	result := runND(t, "--config", configPath, "deploy", "--agents", "bogus", "greeting")
+	if result.ExitCode == 0 {
+		t.Fatal("expected non-zero exit code for unknown agent")
+	}
+	combined := result.Stdout + result.Stderr
+	if !strings.Contains(combined, "bogus") {
+		t.Errorf("error output should mention 'bogus', got: %s", combined)
+	}
+}
+
 func TestDeployCreateSymlink(t *testing.T) {
 	configPath, _ := setupIntegrationEnv(t)
 


### PR DESCRIPTION
## Summary

Adds multi-agent deploy support across TUI and CLI, allowing users to deploy the same assets to multiple detected agents (Claude Code, Copilot, or both) in one operation.

### Changes

**Config:**
- `DefaultDeployAgents []string` field on `Config` and `ProjectConfig`
- Merge logic in `MergeConfigs` (project overrides global)
- Validation rejects unknown agent names

**Engine:**
- `DeployEngineFor(ag)` factory helper on `App` — creates per-agent engines
- `DeployEngine()` refactored to delegate to `DeployEngineFor`

**TUI:**
- New `deployPickAgents` step with multi-select agent picker (between type picker and asset picker)
- Skip logic: `default_deploy_agents` config > single detected agent > show picker
- Multi-agent deploy through per-agent engines with merged results
- Result rendering shows target agent when multi-agent (e.g. `skill/foo -> copilot`)

**CLI:**
- `--agents` flag: `nd deploy --agents claude-code,copilot greeting`
- Resolution precedence: `--agents` > `config.default_deploy_agents` > `ActiveAgent()`
- Validates agent names and detection status
- Per-agent deploy with merged result reporting

**Tests:**
- Config: YAML round-trip, omitempty, validation (valid + unknown names)
- Merge: project override, global preserved when project empty
- TUI: InputActive, FullHelpItems, multi-agent result rendering, single-agent no arrow
- Integration: `--agents claude-code` succeeds, `--agents bogus` fails

### Verification
- `go build -o nd .` ✓
- `go test ./...` ✓
- `go test -race ./internal/tui/...` ✓
- `golangci-lint run` — 0 issues ✓

Closes #79