### PR TITLE
chore(tasks): mark 32 tasks completed after PR #139

### DIFF
--- a/tasks/cli/10iw4s-expand-builtin-init-ux.md
+++ b/tasks/cli/10iw4s-expand-builtin-init-ux.md
@@ -1,7 +1,7 @@
 ---
 title: "Bring builtin source nd init UX into spec"
 id: "10iw4s"
-status: pending
+status: completed
 priority: high
 type: feature
 tags: ["core", "onboarding"]
@@ -27,6 +27,7 @@ context:
   - "internal/state/state.go"
   - "tasks/cli/unaa3u-builtin-source.md"
   - "docs/plans/2026-04-02-002-feat-builtin-source-plan.md"
+completed_at: 2026-08-01
 ---
 
 ## Bring builtin source nd init UX into spec

--- a/tasks/cli/2zlf37-bug-profile-snapshot-toctou.md
+++ b/tasks/cli/2zlf37-bug-profile-snapshot-toctou.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix profile/snapshot create TOCTOU silent overwrite"
 id: "2zlf37"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["profile", "concurrency"]
@@ -25,6 +25,7 @@ context:
   - "internal/state/lock.go"
   - "internal/state/store.go"
   - "internal/profile/store_test.go"
+completed_at: 2026-08-01
 ---
 
 ## Fix profile/snapshot create TOCTOU silent overwrite

--- a/tasks/cli/37uilg-expand-parent-cmd-rune.md
+++ b/tasks/cli/37uilg-expand-parent-cmd-rune.md
@@ -1,7 +1,7 @@
 ---
 title: "Add useful default RunE to parent commands"
 id: "37uilg"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["cli"]
@@ -33,6 +33,7 @@ verify:
     check: "Bare nd source / nd profile / nd snapshot print their list output (not Cobra usage); nd settings opens $EDITOR on the config (or prints the resolved config path)"
   - type: assert
     check: "All nd completion bash|zsh|fish, nd source/profile/snapshot/settings subcommands behave unchanged"
+completed_at: 2026-08-01
 ---
 
 ## Add useful default RunE to parent commands

--- a/tasks/cli/47kdob-fix-handle-selection-export.md
+++ b/tasks/cli/47kdob-fix-handle-selection-export.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix handleSelection missing export case"
 id: "47kdob"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["tui"]
@@ -24,6 +24,7 @@ verify:
     run: "go test ./... -count=1"
   - type: assert
     check: "Selecting \"Export plugin\" in the TUI main menu shows a visible notice telling the user to run `nd export` on the command line, then returns to the main menu on Enter (no silent reset)"
+completed_at: 2026-08-01
 ---
 
 ## Fix handleSelection missing export case

--- a/tasks/cli/6bije3-tui-help-instructions.md
+++ b/tasks/cli/6bije3-tui-help-instructions.md
@@ -1,7 +1,7 @@
 ---
 title: "Add embedded help instructions to TUI"
 id: "6bije3"
-status: pending
+status: completed
 priority: medium
 type: feature
 tags: ["tui", "ux"]
@@ -31,6 +31,7 @@ verify:
     check: "On first TUI launch a dismissible 'Press ? for help' tip appears and never reappears after the help_seen flag is written"
   - type: assert
     check: "Every screen registered in the navigation stack implements HelpProvider or FullHelpProvider"
+completed_at: 2026-08-01
 ---
 
 ## Add embedded help instructions to TUI

--- a/tasks/cli/6irbna-bug-sourcemanager-remove-rollback.md
+++ b/tasks/cli/6irbna-bug-sourcemanager-remove-rollback.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix SourceManager Remove rollback slice corruption"
 id: "6irbna"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["source"]
@@ -23,6 +23,7 @@ context:
   - internal/sourcemanager/config.go
   - internal/sourcemanager/sourcemanager.go
   - internal/nd/atomic.go
+completed_at: 2026-08-01
 ---
 
 ## Fix SourceManager.Remove rollback slice corruption

--- a/tasks/cli/8t7acq-expand-version-sot.md
+++ b/tasks/cli/8t7acq-expand-version-sot.md
@@ -1,7 +1,7 @@
 ---
 title: "Establish version source of truth and release drift check"
 id: "8t7acq"
-status: pending
+status: completed
 priority: high
 type: chore
 tags: ["release"]
@@ -23,15 +23,16 @@ context:
   - "tasks/cli/ps3zxi-merge-v070-release.md"
 verify:
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go build -o /tmp/nd-8t7acq . && /tmp/nd-8t7acq version"
+    run: "go build -o /tmp/nd-8t7acq . && /tmp/nd-8t7acq version"
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go test ./... && go build -o /dev/null ."
+    run: "go test ./... && go build -o /dev/null ."
   - type: assert
     check: "A docs/ or top-level doc names internal/version/version.go:9 as the single product-version source of truth and explains the release-please -> git tag -> goreleaser ldflags -> internal/version flow"
   - type: assert
     check: ".release-please-manifest.json version, the latest git tag (stripped of leading 'v'), and `nd version` output (stripped of leading 'v') all agree, enforced by an automated CI/release check that fails on mismatch"
   - type: assert
     check: "go.mod, .GitHub/workflows/ci.yml, and .GitHub/copilot-instructions.md reference a consistent Go toolchain version (no contradictory pins)"
+completed_at: 2026-08-01
 ---
 
 ## Establish version source of truth and release drift check

--- a/tasks/cli/9k4p5h-bug-atomicwrite-fsync.md
+++ b/tasks/cli/9k4p5h-bug-atomicwrite-fsync.md
@@ -1,7 +1,7 @@
 ---
 title: "Fsync parent directory in AtomicWrite for crash safety"
 id: "9k4p5h"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["core", "durability"]
@@ -25,6 +25,7 @@ verify:
     check: "AtomicWrite opens the parent directory after os.Rename and calls Sync() on it (errors other than unsupported-platform are surfaced); existing temp-file fsync, chmod, and rename behavior is unchanged"
   - type: assert
     check: "A test in internal/nd/atomic_test.go exercises the post-rename directory-fsync path and still passes (no temp files left, content correct)"
+completed_at: 2026-08-01
 ---
 
 ## Fsync parent directory in AtomicWrite for crash safety

--- a/tasks/cli/agtaqm-test-coverage-gaps.md
+++ b/tasks/cli/agtaqm-test-coverage-gaps.md
@@ -1,7 +1,7 @@
 ---
 title: "Address test coverage gaps from TUI audit"
 id: "agtaqm"
-status: pending
+status: completed
 priority: low
 type: chore
 tags: ["testing"]
@@ -35,6 +35,7 @@ context:
   - internal/tui/integration_test.go
   - internal/oplog/oplog.go
   - internal/oplog/writer.go
+completed_at: 2026-08-01
 ---
 
 ## Address test coverage gaps from TUI audit

--- a/tasks/cli/ba5xah-select-deploy-agents.md
+++ b/tasks/cli/ba5xah-select-deploy-agents.md
@@ -1,7 +1,7 @@
 ---
 title: "Let user select target agents for deploy"
 id: "ba5xah"
-status: pending
+status: completed
 priority: high
 type: feature
 tags: ["deploy", "multi-agent"]
@@ -39,6 +39,7 @@ context:
   - "internal/tui/deploy.go"
   - "internal/tui/services.go"
   - "internal/tui/testutil_test.go"
+completed_at: 2026-08-01
 ---
 
 ## Let user select target agents for deploy

--- a/tasks/cli/bbd9oy-update-nd-to-deploy-to-agents-type-by-default.md
+++ b/tasks/cli/bbd9oy-update-nd-to-deploy-to-agents-type-by-default.md
@@ -1,7 +1,7 @@
 ---
 title: "Update nd to deploy to .agents/<type> by default"
 id: "bbd9oy"
-status: pending
+status: completed
 priority: high
 type: feature
 tags: ["deploy", "breaking-change"]
@@ -38,6 +38,7 @@ verify:
     check: "FindProjectRoot detects a directory containing only .agents/ (no .git, no .claude); the not-found error message lists the correct marker(s)"
   - type: assert
     check: "Global scope (~/.claude/...) deploy paths are byte-for-byte unchanged; no global-scope test fixture was modified"
+completed_at: 2026-08-01
 ---
 
 ## Update nd to deploy to .agents/<type> by default

--- a/tasks/cli/cc0u6u-deployment-indicators.md
+++ b/tasks/cli/cc0u6u-deployment-indicators.md
@@ -1,7 +1,7 @@
 ---
 title: "Show deployment indicators in asset lists"
 id: "cc0u6u"
-status: pending
+status: completed
 priority: medium
 type: feature
 tags: ["tui", "deploy"]
@@ -30,6 +30,7 @@ context:
   - internal/asset/identity.go
   - internal/config/config.go
   - cmd/app.go
+completed_at: 2026-08-01
 ---
 
 ## Show deployment indicators in asset lists

--- a/tasks/cli/ce0bw6-init-shell-completions.md
+++ b/tasks/cli/ce0bw6-init-shell-completions.md
@@ -1,7 +1,7 @@
 ---
 title: "Offer shell completion install during init"
 id: "ce0bw6"
-status: pending
+status: completed
 priority: medium
 type: feature
 tags: ["cli", "completions", "onboarding"]
@@ -28,6 +28,7 @@ verify:
     check: "Interactive `nd init` with SHELL=/bin/zsh prints an 'Install shell completions for zsh? [y/N]' prompt after the 'Detected agents:' line and before the built-in deploy prompt; answering y writes ~/.zfunc/_nd and prints the install path; answering n/Enter skips with no error"
   - type: assert
     check: "`nd init --yes`, `nd init --json`, and `nd init --quiet` never prompt for or install completions; an unset or unsupported $SHELL silently skips the step; a filesystem write error during install prints a warning to stderr but `nd init` still exits 0"
+completed_at: 2026-08-01
 ---
 
 ## Offer shell completion install during init

--- a/tasks/cli/dze4e7-expand-silent-tui-handlers.md
+++ b/tasks/cli/dze4e7-expand-silent-tui-handlers.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix silent TUI handlers across screens"
 id: "dze4e7"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["tui"]
@@ -34,6 +34,7 @@ verify:
     check: "Ctrl+S toggle to project scope with no resolvable project root shows a visible message instead of silently doing nothing"
   - type: assert
     check: "Pin no-change, deploy no-selection, and remove no-selection paths each render a visible message before returning"
+completed_at: 2026-08-01
 ---
 
 ## Fix silent TUI handlers across screens

--- a/tasks/cli/fpff5s-bug-state-data-loss.md
+++ b/tasks/cli/fpff5s-bug-state-data-loss.md
@@ -1,7 +1,7 @@
 ---
 title: "Prevent state-file data loss on corrupt-rename and backup collision"
 id: "fpff5s"
-status: pending
+status: completed
 priority: high
 type: bug
 tags: ["state", "data-loss"]
@@ -27,6 +27,7 @@ verify:
     check: "Two existing files with the same basename backed up within a single DeployBulk call produce two distinct backup paths and both survive on disk"
   - type: assert
     check: "DeploymentState.Validate() returns non-empty errors for duplicate identities or an invalid scope, and Store.Load() surfaces that as an error"
+completed_at: 2026-08-01
 ---
 
 ## Prevent state-file data loss on corrupt-rename and backup collision

--- a/tasks/cli/j54b7l-bug-deploy-agent-edge-cases.md
+++ b/tasks/cli/j54b7l-bug-deploy-agent-edge-cases.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix deploy/agent edge cases in backup target default detection and init symlink strategy"
 id: "j54b7l"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["deploy"]
@@ -18,17 +18,18 @@ context:
   - "cmd/app.go"
 verify:
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go build -o nd ."
+    run: "go build -o nd ."
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go test ./internal/deploy/... ./internal/agent/... ./cmd/..."
+    run: "go test ./internal/deploy/... ./internal/agent/... ./cmd/..."
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go test -race ./internal/deploy/... ./internal/agent/... ./cmd/..."
+    run: "go test -race ./internal/deploy/... ./internal/agent/... ./cmd/..."
   - type: assert
     check: "Foreign-symlink conflict backup warning for a context asset includes the previous symlink target path"
   - type: assert
     check: "Registry.Default() does not select a binary-less stale GlobalDir over an agent whose binary is in PATH"
   - type: assert
     check: "nd init built-in deploy uses SymlinkRelative when the written config sets symlink_strategy: relative"
+completed_at: 2026-08-01
 ---
 
 ## Fix deploy/agent edge cases

--- a/tasks/cli/kn08l6-bug-lock-break-race.md
+++ b/tasks/cli/kn08l6-bug-lock-break-race.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix unsafe state lock-break race"
 id: "kn08l6"
-status: pending
+status: completed
 priority: high
 type: bug
 tags: ["state", "concurrency"]
@@ -26,6 +26,7 @@ context:
   - "internal/nd/errors.go"
   - "internal/nd/atomic.go"
   - "internal/deploy/deploy.go"
+completed_at: 2026-08-01
 ---
 
 ## Fix unsafe state lock-break race

--- a/tasks/cli/nxvr4w-deploy-scope-prompt.md
+++ b/tasks/cli/nxvr4w-deploy-scope-prompt.md
@@ -1,7 +1,7 @@
 ---
 title: "Offer global or project scope on deploy"
 id: "nxvr4w"
-status: pending
+status: completed
 priority: medium
 type: feature
 tags: ["deploy", "ux"]
@@ -34,6 +34,7 @@ verify:
     check: "After the first prompt answer, subsequent deploys in the same process do not re-prompt (session preference is reused)."
   - type: assert
     check: "`--json` or non-TTY stdin with no explicit `--scope` does not block on a prompt; it proceeds with the resolved default scope (no hang, no error introduced for existing scripted callers)."
+completed_at: 2026-08-01
 ---
 
 ## Offer global or project scope on deploy

--- a/tasks/cli/oema5w-expand-docs-undocumented-cli.md
+++ b/tasks/cli/oema5w-expand-docs-undocumented-cli.md
@@ -1,7 +1,7 @@
 ---
 title: "Document undocumented CLI flags and correct stale doc tasks"
 id: "oema5w"
-status: pending
+status: completed
 priority: medium
 type: chore
 tags: ["docs"]
@@ -36,6 +36,7 @@ verify:
     check: "--absolute is documented with a runnable example in at least one docs/guide/*.md file"
   - type: assert
     check: "cmd/gendocs/main.go guideTitles has no unused keys, OR every remaining key is justified in this task's worklog"
+completed_at: 2026-08-01
 ---
 
 ## Document undocumented CLI flags and correct stale doc tasks

--- a/tasks/cli/ojhux3-bug-oplog-writer-reliability.md
+++ b/tasks/cli/ojhux3-bug-oplog-writer-reliability.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix oplog writer ignored Close and swallowed rotation error"
 id: "ojhux3"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["state"]
@@ -23,6 +23,7 @@ verify:
     check: "oplog.Writer.Log returns a non-nil error if f.Close() fails after a successful Write"
   - type: assert
     check: "rotateIfNeeded only treats fs.ErrNotExist as 'no file yet'; any other os.Stat error is returned, not swallowed"
+completed_at: 2026-08-01
 ---
 
 ## Fix oplog writer ignored close and swallowed rotation error

--- a/tasks/cli/r8j6i9-expand-stale-cache.md
+++ b/tasks/cli/r8j6i9-expand-stale-cache.md
@@ -1,7 +1,7 @@
 ---
 title: "Fix stale builtin cache and long-lived SourceManager config"
 id: "r8j6i9"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["cli", "deploy"]
@@ -35,6 +35,7 @@ context:
   - "internal/tui/source.go"
   - "internal/version/version.go"
   - "tasks/cli/7s19kh-fix-deploy-stale-cache.md"
+completed_at: 2026-08-01
 ---
 
 ## Fix stale builtin cache and long-lived SourceManager config

--- a/tasks/cli/rrts5a-docs-tier2-content-gaps.md
+++ b/tasks/cli/rrts5a-docs-tier2-content-gaps.md
@@ -1,7 +1,7 @@
 ---
 title: "Docs Tier 2: fill content gaps"
 id: "rrts5a"
-status: pending
+status: completed
 priority: medium
 type: chore
 tags: ["docs"]
@@ -16,15 +16,16 @@ context:
   - "scripts/lint-docs.sh"
 verify:
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go build -o /tmp/nd-rrts5a ./cmd/gendocs/ && rm -f /tmp/nd-rrts5a"
+    run: "go build -o /tmp/nd-rrts5a ./cmd/gendocs/ && rm -f /tmp/nd-rrts5a"
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && go run ./cmd/gendocs/ && git diff --quiet docs/reference/ || (echo 'reference docs out of sync; commit regenerated output' && exit 1)"
+    run: "go run ./cmd/gendocs/ && git diff --quiet docs/reference/ || (echo 'reference docs out of sync; commit regenerated output' && exit 1)"
   - type: bash
-    run: "cd /Users/larah/Repos/Personal/nd && scripts/lint-docs.sh docs/guide/getting-started.md docs/guide/troubleshooting.md docs/guide/asset-types/plugins.md"
+    run: "scripts/lint-docs.sh docs/guide/getting-started.md docs/guide/troubleshooting.md docs/guide/asset-types/plugins.md"
   - type: assert
     check: "docs/reference/nd_source_remove.md documents that --yes silently removes all deployed assets from the source (the destructive default)."
   - type: assert
     check: "cmd/gendocs/main.go guideTitles map has no entry that is absent from every docs.guides annotation in cmd/*.go (the only candidate was 'glossary')."
+completed_at: 2026-08-01
 ---
 
 ## Docs tier 2: fill content gaps

--- a/tasks/cli/unaa3u-builtin-source.md
+++ b/tasks/cli/unaa3u-builtin-source.md
@@ -1,7 +1,7 @@
 ---
 title: "Ship built-in source with nd"
 id: "unaa3u"
-status: pending
+status: completed
 priority: high
 type: feature
 tags: ["core", "onboarding"]
@@ -33,6 +33,7 @@ verify:
     run: "go test ./tests/integration/ -run Builtin -v"
   - type: assert
     check: "An end-to-end integration test in tests/integration/ exercises `nd init --yes` then asserts builtin assets are deployed and `nd source list` includes a source with type builtin that `nd source remove builtin` refuses to delete"
+completed_at: 2026-08-01
 ---
 
 ## Ship built-in source with nd

--- a/tasks/cli/vrs2d7-expand-tui-helpprovider.md
+++ b/tasks/cli/vrs2d7-expand-tui-helpprovider.md
@@ -1,7 +1,7 @@
 ---
 title: "Implement HelpProvider on TUI screens missing it"
 id: "vrs2d7"
-status: pending
+status: completed
 priority: medium
 type: feature
 tags: ["tui", "ux"]
@@ -38,6 +38,7 @@ verify:
     check: "All 13 screen constructors (newBrowseScreen, newDeployScreen, newDoctorScreen, newFirstRunScreen, newMainMenuScreen, newProfileScreen, newPinScreen, newRemoveScreen, newScopeScreen, newSettingsScreen, newSnapshotScreen, newSourceScreen, newStatusScreen) return a value satisfying HelpProvider or FullHelpProvider"
   - type: assert
     check: "On a huh MultiSelect step the help bar shows 'x/space toggle' (not 'enter select'); on a huh Confirm step it shows 'h/l yes/no'; on a text-input step it does not show 'enter select'"
+completed_at: 2026-08-01
 ---
 
 ## Implement HelpProvider on TUI screens missing it

--- a/tasks/cli/wdisqq-expand-cmd-flag-consistency.md
+++ b/tasks/cli/wdisqq-expand-cmd-flag-consistency.md
@@ -1,7 +1,7 @@
 ---
 title: "Normalize yes/json/quiet/non-TTY handling across commands"
 id: "wdisqq"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["cli", "ux"]
@@ -46,6 +46,7 @@ verify:
     check: "Under --json, no command writes human (non-JSON) text to stdout (cancellation/aborted lines go to stderr or are suppressed); under --quiet, cancellation messages are uniformly suppressed."
   - type: assert
     check: "`nd settings edit --json` / `--quiet` / non-TTY does not exec $EDITOR (does not hang a scripted run); it returns an actionable error instead."
+completed_at: 2026-08-01
 ---
 
 ## Normalize --yes/--json/--quiet/non-TTY handling across commands

--- a/tasks/cli/wughc0-expand-test-coverage-nontui.md
+++ b/tasks/cli/wughc0-expand-test-coverage-nontui.md
@@ -1,7 +1,7 @@
 ---
 title: "Additional test coverage gaps beyond TUI audit"
 id: "wughc0"
-status: pending
+status: completed
 priority: low
 type: chore
 tags: ["testing"]
@@ -34,6 +34,7 @@ context:
   - cmd/deploy_test.go
   - cmd/oplog_integration_test.go
   - tasks/cli/agtaqm-test-coverage-gaps.md
+completed_at: 2026-08-01
 ---
 
 ## Additional test coverage gaps beyond TUI audit

--- a/tasks/cli/wui1vo-expand-single-agent-assumptions.md
+++ b/tasks/cli/wui1vo-expand-single-agent-assumptions.md
@@ -1,7 +1,7 @@
 ---
 title: "Catalog and refactor single-agent assumption sites"
 id: "wui1vo"
-status: pending
+status: completed
 priority: high
 type: feature
 tags: ["deploy", "multi-agent"]
@@ -47,6 +47,7 @@ context:
   - "internal/tui/deploy.go"
   - "internal/profile/manager.go"
   - "tasks/cli/ba5xah-select-deploy-agents.md"
+completed_at: 2026-08-01
 ---
 
 ## Catalog and refactor single-agent assumption sites

--- a/tasks/tui/2r0nyd-tui-project-scope-switch.md
+++ b/tasks/tui/2r0nyd-tui-project-scope-switch.md
@@ -1,7 +1,7 @@
 ---
 title: "TUI scope switch to project fails with 'no project root detected' when launched in global scope"
 id: "2r0nyd"
-status: pending
+status: completed
 priority: high
 type: bug
 tags: ["tui", "scope", "bug"]
@@ -31,6 +31,7 @@ verify:
     check: "Switching to project scope from a directory with no .git/ or .claude/ marker still shows a clear error mentioning .git/ or .claude/."
   - type: assert
     check: "All three entry points (scope.go form, settings.go scope submenu, tui.go ctrl+s toggle) resolve the root on demand and behave consistently."
+completed_at: 2026-08-01
 ---
 
 ## TUI scope switch to project fails with 'no project root detected' when launched in global scope
@@ -100,7 +101,7 @@ Settings -> "Switch scope", `internal/tui/settings.go:68`).
 ### Steps to reproduce
 
 1. `cd` into a valid project directory (one containing `.git/` or `.claude/`),
-   e.g. this repo root `/Users/larah/Repos/Personal/nd`.
+   e.g. this repo root.
 2. Run `nd` with no flags (defaults to global scope; launches the TUI).
 3. From the main menu choose "Switch scope" (or Settings -> "Switch scope", or
    press `ctrl+s`).

--- a/tasks/tui/439d2n-bug-tui-double-fire.md
+++ b/tasks/tui/439d2n-bug-tui-double-fire.md
@@ -1,7 +1,7 @@
 ---
 title: "Add double-fire guard to TUI create/save/add forms"
 id: "439d2n"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["tui"]
@@ -26,6 +26,7 @@ verify:
     run: "golangci-lint run ./internal/tui/..."
   - type: assert
     check: "runCreate/runSave/runAdd fire exactly once per form completion even when Update is called again after huh.StateCompleted"
+completed_at: 2026-08-01
 ---
 
 ## Add double-fire guard to TUI create/save/add forms

--- a/tasks/tui/k63tsg-expand-project-root-resolution.md
+++ b/tasks/tui/k63tsg-expand-project-root-resolution.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolve project root on demand in TUI deploy/profile and sourcemanager"
 id: "k63tsg"
-status: pending
+status: completed
 priority: high
 type: bug
 tags: ["tui", "scope"]
@@ -39,6 +39,7 @@ verify:
     check: "SourceManager merges .nd/config.yaml project config when cwd is inside a project, regardless of launch scope"
   - type: assert
     check: "A cwd that is not inside any project still produces the FindProjectRoot error ('looked for .git/ or .claude/ from ...')"
+completed_at: 2026-08-01
 ---
 
 ## Resolve project root on demand in TUI deploy/profile and sourcemanager

--- a/tasks/tui/pio815-bug-tui-stale-list.md
+++ b/tasks/tui/pio815-bug-tui-stale-list.md
@@ -1,7 +1,7 @@
 ---
 title: "Refresh TUI screen list after create/save/add mutation"
 id: "pio815"
-status: pending
+status: completed
 priority: medium
 type: bug
 tags: ["tui"]
@@ -31,6 +31,7 @@ context:
   - internal/tui/testutil_test.go
   - internal/tui/services.go
   - internal/tui/screens.go
+completed_at: 2026-08-01
 ---
 
 ## Refresh TUI screen list after create/save/add mutation

--- a/tasks/tui/qrmcc2-cleanup-tui-minor.md
+++ b/tasks/tui/qrmcc2-cleanup-tui-minor.md
@@ -1,7 +1,7 @@
 ---
 title: "TUI minor cleanups for dead code and unsurfaced sync error"
 id: "qrmcc2"
-status: pending
+status: completed
 priority: low
 type: chore
 tags: ["tui"]
@@ -24,6 +24,7 @@ verify:
     check: "header.go View() no longer declares a misleadingly-named `leftStyled` variable that holds an unstyled string; the left segment is emitted via `left` directly (or genuinely styled)."
   - type: assert
     check: "A source sync failure renders through the same error-display code path/styling as a source load failure (the `s.err != nil && s.step == sourceDone` branch in View()), not a separate doneMsg-only path."
+completed_at: 2026-08-01
 ---
 
 ## TUI minor cleanups


### PR DESCRIPTION
## Why

[PR #139](https://github.com/armstrongl/nd/pull/139) landed 33 backlog tasks into `main` on 2026-07-08, but its body closes with:

> taskmd statuses were intentionally **not** modified — do that after merge.

That follow-up never happened, so `taskmd list` has been overstating the remaining backlog by ~33 items. This PR reconciles the backlog with what actually shipped.

## Verification

Every task was verified before flipping — no status was taken on trust.

| Gate | Result |
|---|---|
| `go build ./...` / `go vet ./...` | ✅ |
| `go test ./...` (21 packages) | ✅ |
| `go test -race ./...` | ✅ |
| `golangci-lint run` | ✅ 0 issues |
| Per-task bash checks (`lint-docs.sh`, gendocs build, `check-version-drift.sh`) | ✅ |
| 85 `assert` checks across 33 tasks | reviewed against the code |

Repo-wide gates were run once rather than per task, since every per-task bash step is a subset of them.

## Changes

**32 tasks `pending` → `completed`**, each with its GitHub issue closed via `scripts/taskmd-issue-sync.py`.

**1 task deliberately left pending — `vkerqg`** (Update docs to be agent-agnostic). Its first assert requires that no generic prose assumes Claude Code is the only agent, but two files still do:

- `docs/guide/team-config.md:91` — "deploys into the repository's `.claude/` directory instead of the user-wide `~/.claude/`"
- `docs/guide/tui.md:115` — "the global agent directory (`~/.claude/`) or the project directory (`.claude/`)"

Both are now doubly stale: `bbd9oy` (in this same batch) changed the default project directory to `.agents/<type>`.

**3 cancelled-task issues closed as not-planned:** #115 (`7l7r5d`), #60 (`7s19kh`), #124 (`bagcdr`).

**3 issues deliberately left open** — each is linked from more than one task, and in every case the other task is still pending or cancelled:

| Issue | Why it stays open |
|---|---|
| #62 | Also linked from `9awxuj` (cancelled); the issue's subject — shell detection — is `9awxuj`'s, not `37uilg`'s |
| #77 | Also linked from `r2uj81`, still pending |
| #104 | The auto-filed *AFDocs compliance check failing* issue; that check is still red on `main` |

**4 task files had broken verify blocks** hardcoding `cd /Users/larah/Repos/Personal/nd` — a directory that does not exist. Their checks failed regardless of the underlying work. Prefix stripped; `taskmd verify` already runs from the repo root.

## Result

`taskmd validate` → all 45 tasks valid. Backlog is now 32 completed / 8 pending / 5 cancelled, down from 40 pending.

The diff touches `tasks/**` only — no source changes.

## Note on CI

The markdown-lint job is expected to fail on this branch. It is **pre-existing and unrelated**: 63 issues, 60 of them in `docs/SUMMARY.md`, introduced by the GitBook sync commit (2b94868) writing `*` list markers where the repo style is `-`. Not fixed here.
