### PR TITLE
ci: auto-format PRs with rumdl and gofmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,14 +22,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          # A PAT makes the format commit re-trigger CI. With the default
-          # GITHUB_TOKEN, pushes deliberately do not start new workflow runs,
-          # so the PR's checks stay pinned to the pre-format commit.
+          # A PAT makes the format commit re-trigger CI normally. With the
+          # default GITHUB_TOKEN, GitHub creates runs for the pushed commit but
+          # parks them at conclusion `action_required` without executing them,
+          # so the PR is left showing checks that need manual approval.
+          # Verified live on this workflow's own PR.
           token: ${{ secrets.FORMAT_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      # Only relevant when FORMAT_PAT is set: without it the push cannot
-      # re-trigger this workflow, so there is nothing to loop on.
+      # Only bites when FORMAT_PAT is set; without it the re-triggered run
+      # never executes, so there is nothing to loop on either way.
       - name: Skip if HEAD is already a format commit
         id: guard
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,71 @@
+name: Format
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: format-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Auto-format
+    runs-on: ubuntu-latest
+    # Forks get a read-only token on `pull_request`, so the push back would
+    # fail. Skip them; CI still gates the result via `rumdl check .`.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          # A PAT makes the format commit re-trigger CI. With the default
+          # GITHUB_TOKEN, pushes deliberately do not start new workflow runs,
+          # so the PR's checks stay pinned to the pre-format commit.
+          token: ${{ secrets.FORMAT_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      # Only relevant when FORMAT_PAT is set: without it the push cannot
+      # re-trigger this workflow, so there is nothing to loop on.
+      - name: Skip if HEAD is already a format commit
+        id: guard
+        run: |
+          if git log -1 --pretty=%s | grep -q '^style: apply auto-formatting$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-go@v5
+        if: steps.guard.outputs.skip == 'false'
+        with:
+          go-version-file: go.mod
+
+      - name: Install rumdl
+        if: steps.guard.outputs.skip == 'false'
+        # Pinned to match the version the Lint Markdown job checks against.
+        run: pip install rumdl==0.1.69
+
+      - name: Format markdown
+        if: steps.guard.outputs.skip == 'false'
+        run: rumdl fmt .
+
+      - name: Format Go
+        if: steps.guard.outputs.skip == 'false'
+        run: gofmt -w .
+
+      - name: Commit and push
+        if: steps.guard.outputs.skip == 'false'
+        run: |
+          if git diff --quiet; then
+            echo "Already formatted; nothing to commit."
+            exit 0
+          fi
+          git diff --stat
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "style: apply auto-formatting"
+          git push origin HEAD:"$GITHUB_HEAD_REF"

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -26,7 +26,7 @@ func newDoctorCmd(app *App) *cobra.Command {
 			"docs.guides":  "getting-started,troubleshooting",
 			"docs.related": "nd status,nd sync",
 		},
-		Args:  cobra.NoArgs,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 			report := doctor.Report{}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -36,7 +36,7 @@ func newListCmd(app *App) *cobra.Command {
 			"docs.guides":  "getting-started,creating-sources,asset-types/skills,asset-types/agents,asset-types/commands,asset-types/rules",
 			"docs.related": "nd deploy",
 		},
-		Args:  cobra.NoArgs,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 
@@ -180,4 +180,3 @@ func newListCmd(app *App) *cobra.Command {
 	})
 	return cmd
 }
-

--- a/cmd/pin.go
+++ b/cmd/pin.go
@@ -20,7 +20,7 @@ func newPinCmd(app *App) *cobra.Command {
 			"docs.guides":  "profiles-and-snapshots",
 			"docs.related": "nd unpin,nd deploy",
 		},
-		Args:  cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setAssetOrigin(cmd, app, args[0], nd.OriginPinned, "Pinned")
 		},
@@ -41,7 +41,7 @@ func newUnpinCmd(app *App) *cobra.Command {
 			"docs.guides":  "profiles-and-snapshots",
 			"docs.related": "nd pin,nd deploy",
 		},
-		Args:  cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setAssetOrigin(cmd, app, args[0], nd.OriginManual, "Unpinned")
 		},

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -31,7 +31,7 @@ func newRemoveCmd(app *App) *cobra.Command {
 			"docs.guides":  "getting-started,how-nd-works,profiles-and-snapshots",
 			"docs.related": "nd deploy,nd status",
 		},
-		Args:  cobra.ArbitraryArgs,
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -24,7 +24,7 @@ func newStatusCmd(app *App) *cobra.Command {
 			"docs.guides":  "getting-started,troubleshooting",
 			"docs.related": "nd doctor,nd deploy",
 		},
-		Args:  cobra.NoArgs,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -21,7 +21,7 @@ func newUninstallCmd(app *App) *cobra.Command {
 		Annotations: map[string]string{
 			"docs.guides": "getting-started,troubleshooting",
 		},
-		Args:  cobra.NoArgs,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := cmd.OutOrStdout()
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -9,33 +9,33 @@ import (
 
 func claudeCode() agent.Agent {
 	return agent.Agent{
-		Name:               "claude-code",
-		GlobalDir:          "/Users/dev/.claude",
-		ProjectDir:         ".agents",
-		SourceAlias:        "claude",
-		Binary:             "claude",
-		SupportedTypes:     nd.DeployableAssetTypes(),
-		DefaultContextFile: "",
+		Name:                "claude-code",
+		GlobalDir:           "/Users/dev/.claude",
+		ProjectDir:          ".agents",
+		SourceAlias:         "claude",
+		Binary:              "claude",
+		SupportedTypes:      nd.DeployableAssetTypes(),
+		DefaultContextFile:  "",
 		ContextInProjectDir: false,
-		VersionPattern:     `(?i)claude`,
-		Detected:           true,
-		InPath:             true,
+		VersionPattern:      `(?i)claude`,
+		Detected:            true,
+		InPath:              true,
 	}
 }
 
 func copilot() agent.Agent {
 	return agent.Agent{
-		Name:               "copilot",
-		GlobalDir:          "/Users/dev/.copilot",
-		ProjectDir:         ".github",
-		SourceAlias:        "copilot",
-		Binary:             "copilot",
-		SupportedTypes:     []nd.AssetType{nd.AssetSkill, nd.AssetAgent, nd.AssetContext},
-		DefaultContextFile: "copilot-instructions.md",
+		Name:                "copilot",
+		GlobalDir:           "/Users/dev/.copilot",
+		ProjectDir:          ".github",
+		SourceAlias:         "copilot",
+		Binary:              "copilot",
+		SupportedTypes:      []nd.AssetType{nd.AssetSkill, nd.AssetAgent, nd.AssetContext},
+		DefaultContextFile:  "copilot-instructions.md",
 		ContextInProjectDir: true,
-		VersionPattern:     `(?i)copilot|github\.copilot`,
-		Detected:           true,
-		InPath:             true,
+		VersionPattern:      `(?i)copilot|github\.copilot`,
+		Detected:            true,
+		InPath:              true,
 	}
 }
 

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -8,12 +8,12 @@ import (
 // Report is the aggregate output of nd doctor.
 // Each section corresponds to a check category.
 type Report struct {
-	Config      ConfigCheck        `json:"config"`
-	Sources     []SourceCheck      `json:"sources"`
+	Config      ConfigCheck         `json:"config"`
+	Sources     []SourceCheck       `json:"sources"`
 	Deployments []state.HealthCheck `json:"deployments"`
-	Agents      []AgentCheck       `json:"agents"`
-	Git         GitCheck           `json:"git"`
-	Summary     Summary            `json:"summary"`
+	Agents      []AgentCheck        `json:"agents"`
+	Git         GitCheck            `json:"git"`
+	Summary     Summary             `json:"summary"`
 }
 
 // ConfigCheck reports config file validation results.

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestReportJSONRoundTrip(t *testing.T) {
 	r := doctor.Report{
-		Config: doctor.ConfigCheck{GlobalValid: true, ProjectValid: true},
-		Git:    doctor.GitCheck{Available: true, Version: "2.44.0"},
+		Config:  doctor.ConfigCheck{GlobalValid: true, ProjectValid: true},
+		Git:     doctor.GitCheck{Available: true, Version: "2.44.0"},
 		Summary: doctor.Summary{Pass: 5, Warn: 1, Fail: 0},
 	}
 	data, err := json.Marshal(&r)

--- a/internal/oplog/oplog.go
+++ b/internal/oplog/oplog.go
@@ -22,16 +22,16 @@ type LogEntry struct {
 type OperationType string
 
 const (
-	OpDeploy          OperationType = "deploy"
-	OpRemove          OperationType = "remove"
-	OpSync            OperationType = "sync"
-	OpProfileSwitch   OperationType = "profile-switch"
-	OpSnapshotSave    OperationType = "snapshot-save"
-	OpSnapshotRestore OperationType = "snapshot-restore"
-	OpSourceAdd       OperationType = "source-add"
-	OpSourceRemove    OperationType = "source-remove"
-	OpSourceSync      OperationType = "source-sync"
-	OpUninstall          OperationType = "uninstall"
-	OpExport             OperationType = "export"
-	OpExportMarketplace  OperationType = "export-marketplace"
+	OpDeploy            OperationType = "deploy"
+	OpRemove            OperationType = "remove"
+	OpSync              OperationType = "sync"
+	OpProfileSwitch     OperationType = "profile-switch"
+	OpSnapshotSave      OperationType = "snapshot-save"
+	OpSnapshotRestore   OperationType = "snapshot-restore"
+	OpSourceAdd         OperationType = "source-add"
+	OpSourceRemove      OperationType = "source-remove"
+	OpSourceSync        OperationType = "source-sync"
+	OpUninstall         OperationType = "uninstall"
+	OpExport            OperationType = "export"
+	OpExportMarketplace OperationType = "export-marketplace"
 )

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -2,7 +2,7 @@ package output
 
 // JSONResponse is the standard envelope for all --json output.
 type JSONResponse struct {
-	Status string      `json:"status"`               // "ok", "error", "partial"
+	Status string      `json:"status"` // "ok", "error", "partial"
 	DryRun bool        `json:"dry_run,omitempty"`
 	Data   interface{} `json:"data,omitempty"`
 	Errors []JSONError `json:"errors,omitempty"`

--- a/internal/profile/switch_diff_test.go
+++ b/internal/profile/switch_diff_test.go
@@ -21,9 +21,9 @@ func TestComputeSwitchDiff(t *testing.T) {
 	target := &profile.Profile{
 		Version: 1, Name: "target", CreatedAt: now, UpdatedAt: now,
 		Assets: []profile.ProfileAsset{
-			{SourceID: "s1", AssetType: nd.AssetSkill, AssetName: "a", Scope: nd.ScopeGlobal},  // keep
-			{SourceID: "s1", AssetType: nd.AssetSkill, AssetName: "d", Scope: nd.ScopeGlobal},  // deploy
-			{SourceID: "s1", AssetType: nd.AssetAgent, AssetName: "c", Scope: nd.ScopeGlobal},  // different scope = remove + deploy
+			{SourceID: "s1", AssetType: nd.AssetSkill, AssetName: "a", Scope: nd.ScopeGlobal}, // keep
+			{SourceID: "s1", AssetType: nd.AssetSkill, AssetName: "d", Scope: nd.ScopeGlobal}, // deploy
+			{SourceID: "s1", AssetType: nd.AssetAgent, AssetName: "c", Scope: nd.ScopeGlobal}, // different scope = remove + deploy
 		},
 	}
 

--- a/internal/profile/validate_test.go
+++ b/internal/profile/validate_test.go
@@ -17,13 +17,13 @@ func TestValidateNameAcceptsValid(t *testing.T) {
 
 func TestValidateNameRejectsInvalid(t *testing.T) {
 	invalid := []string{
-		"",              // empty
-		"has spaces",    // spaces
+		"",               // empty
+		"has spaces",     // spaces
 		"path/traversal", // slashes
-		"../escape",     // dot-dot
-		".hidden",       // leading dot
-		"special!char",  // special char
-		"a@b",           // at sign
+		"../escape",      // dot-dot
+		".hidden",        // leading dot
+		"special!char",   // special char
+		"a@b",            // at sign
 	}
 	for _, name := range invalid {
 		if err := profile.ValidateName(name); err == nil {

--- a/internal/tui/browse.go
+++ b/internal/tui/browse.go
@@ -35,14 +35,14 @@ type browseScreen struct {
 	cursor      int
 	filter      filterInput
 	notice      string // transient feedback (e.g. "already deployed")
-	err       error
-	loaded    bool
+	err         error
+	loaded      bool
 
 	// generation is incremented on every ScopeSwitchedMsg so that stale
 	// browseLoadedMsg results from a previous scope's goroutine are discarded.
 	generation uint64
 
-	height int       // terminal height, updated by tea.WindowSizeMsg
+	height int // terminal height, updated by tea.WindowSizeMsg
 	scroll listScroll
 }
 

--- a/internal/tui/browse_test.go
+++ b/internal/tui/browse_test.go
@@ -481,7 +481,7 @@ func TestBrowseScreen_ScrollOffsetAdjustsWhenCursorMovesUp(t *testing.T) {
 	s.cursor = 9
 	s.scroll.offset = 5
 	s.Update(tea.KeyPressMsg(tea.Key{Code: 'k', Text: "k"})) // cursor → 8, fine
-	s.scroll.offset = 5                                       // force offset above cursor
+	s.scroll.offset = 5                                      // force offset above cursor
 	s.cursor = 3
 	s.Update(tea.KeyPressMsg(tea.Key{Code: 'k', Text: "k"})) // cursor → 2 < offset 5 → adjust
 

--- a/internal/tui/export.go
+++ b/internal/tui/export.go
@@ -21,7 +21,7 @@ func newExportScreen(svc Services, styles Styles, isDark bool) *exportScreen {
 	return &exportScreen{styles: styles}
 }
 
-func (s *exportScreen) Title() string    { return "Export" }
+func (s *exportScreen) Title() string     { return "Export" }
 func (s *exportScreen) InputActive() bool { return false }
 
 func (s *exportScreen) Init() tea.Cmd { return nil }

--- a/internal/tui/firstrun.go
+++ b/internal/tui/firstrun.go
@@ -55,7 +55,7 @@ func newFirstRunScreen(svc Services, styles Styles, isDark bool) *firstRunScreen
 	return f
 }
 
-func (f *firstRunScreen) Title() string    { return "Welcome" }
+func (f *firstRunScreen) Title() string     { return "Welcome" }
 func (f *firstRunScreen) InputActive() bool { return !f.navigated }
 
 // FullHelpItems returns the welcome-screen keybindings for the help bar and overlay.

--- a/internal/tui/helpbar_test.go
+++ b/internal/tui/helpbar_test.go
@@ -12,11 +12,11 @@ import (
 // (tea.Model + Title() + InputActive()).
 type helpTestScreen struct{}
 
-func (helpTestScreen) Init() tea.Cmd                            { return nil }
+func (helpTestScreen) Init() tea.Cmd                           { return nil }
 func (helpTestScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) { return helpTestScreen{}, nil }
-func (helpTestScreen) View() tea.View                           { return tea.NewView("") }
-func (helpTestScreen) Title() string                            { return "test" }
-func (helpTestScreen) InputActive() bool                        { return false }
+func (helpTestScreen) View() tea.View                          { return tea.NewView("") }
+func (helpTestScreen) Title() string                           { return "test" }
+func (helpTestScreen) InputActive() bool                       { return false }
 
 // helpTestScreenWithItems is a screen that also implements HelpProvider.
 type helpTestScreenWithItems struct{ helpTestScreen }

--- a/internal/tui/main_menu.go
+++ b/internal/tui/main_menu.go
@@ -60,7 +60,7 @@ func newMainMenuScreen(svc Services, styles Styles, isDark bool) *mainMenuScreen
 }
 
 // Screen interface
-func (m *mainMenuScreen) Title() string    { return "Main Menu" }
+func (m *mainMenuScreen) Title() string     { return "Main Menu" }
 func (m *mainMenuScreen) InputActive() bool { return false }
 
 // FullHelpItems returns the menu keybindings for the help bar and overlay.

--- a/internal/tui/main_menu_test.go
+++ b/internal/tui/main_menu_test.go
@@ -247,4 +247,3 @@ func TestMainMenu_FirstOptionIsDeployNotSeparator(t *testing.T) {
 		t.Fatalf("choice = %q after construction, want %q (first option must be a real item, not separator)", m.choice, "deploy")
 	}
 }
-

--- a/internal/tui/pin.go
+++ b/internal/tui/pin.go
@@ -62,7 +62,7 @@ func newPinScreen(svc Services, styles Styles, isDark bool) *pinScreen {
 	return &pinScreen{svc: svc, styles: styles, isDark: isDark}
 }
 
-func (s *pinScreen) Title() string     { return "Pin/Unpin" }
+func (s *pinScreen) Title() string { return "Pin/Unpin" }
 func (s *pinScreen) InputActive() bool {
 	return s.step == pinSelect || s.step == pinConfirm
 }

--- a/internal/tui/remove.go
+++ b/internal/tui/remove.go
@@ -365,7 +365,7 @@ func (m *removeScreen) buildRemoveRequests() []deploy.RemoveRequest {
 		if d, ok := lookup[key]; ok {
 			reqs = append(reqs, deploy.RemoveRequest{
 				Identity:    d.Identity(),
-				Scope:       d.Scope,       // H3: use deployment's recorded scope
+				Scope:       d.Scope, // H3: use deployment's recorded scope
 				ProjectRoot: d.ProjectPath,
 			})
 		}

--- a/internal/tui/scope.go
+++ b/internal/tui/scope.go
@@ -62,7 +62,7 @@ func newScopeErrorScreen(svc Services, styles Styles, isDark bool, msg string) *
 	return s
 }
 
-func (s *scopeScreen) Title() string    { return "Switch Scope" }
+func (s *scopeScreen) Title() string     { return "Switch Scope" }
 func (s *scopeScreen) InputActive() bool { return s.step == scopeFormStep && !s.navigated }
 
 // FullHelpItems returns step-specific keybindings for the help bar and overlay.

--- a/internal/tui/screens.go
+++ b/internal/tui/screens.go
@@ -5,8 +5,8 @@ import tea "charm.land/bubbletea/v2"
 // Screen is a TUI view that the root model manages on a stack.
 type Screen interface {
 	tea.Model
-	Title() string      // Displayed in breadcrumb context.
-	InputActive() bool  // True when a text field has focus (suppresses global keys).
+	Title() string     // Displayed in breadcrumb context.
+	InputActive() bool // True when a text field has focus (suppresses global keys).
 }
 
 // Navigation messages — screens emit these, root model handles them.

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -73,7 +73,7 @@ func (s *settingsScreen) buildMenu() {
 	).WithTheme(huh.ThemeFunc(huh.ThemeCatppuccin))
 }
 
-func (s *settingsScreen) Title() string    { return "Settings" }
+func (s *settingsScreen) Title() string { return "Settings" }
 func (s *settingsScreen) InputActive() bool {
 	return s.step == settingsMenu || s.step == settingsSwitchScope
 }

--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -30,8 +30,8 @@ type statusScreen struct {
 	// statusLoadedMsg results from a previous scope's goroutine are discarded.
 	generation uint64
 
-	renderedLines []string  // content lines cached after data loads
-	height        int       // terminal height, updated by tea.WindowSizeMsg
+	renderedLines []string // content lines cached after data loads
+	height        int      // terminal height, updated by tea.WindowSizeMsg
 	scroll        listScroll
 }
 


### PR DESCRIPTION
## Summary

Adds a `Format` workflow that runs the repo's formatters on every PR and pushes the result back to the PR branch. Motivated by #143, where markdown from the GitBook sync left `main` failing the `rumdl check .` gate and blocked an unrelated PR.

## The workflow

`.github/workflows/format.yml`, on `pull_request` (opened / synchronize / reopened):

- Runs `rumdl fmt .` (pinned to `0.1.69`, matching the Lint Markdown gate) and `gofmt -w .` repo-wide, then commits only if something actually changed.
- Skips forks — `pull_request` grants them a read-only token, so the push back would fail. CI's `rumdl check .` still gates the result.
- Uses `secrets.FORMAT_PAT` when present, falling back to `secrets.GITHUB_TOKEN`.
- Guards against a re-trigger loop by skipping when `HEAD` is already a `style: apply auto-formatting` commit.
- `concurrency` group per PR with `cancel-in-progress`.

### Setup note — `FORMAT_PAT` is not currently set

I live-tested the push path on this PR by committing a deliberately misformatted Go file. The bot correctly detected it, fixed it, and pushed `style: apply auto-formatting` back to the branch.

The token behavior is worth stating precisely, because it is not quite the usual "GITHUB_TOKEN pushes don't trigger workflows" summary. GitHub *does* create runs for the bot's commit, but parks them at conclusion `action_required` and never executes them — so the PR is left showing checks that need manual approval, rather than showing no new checks at all.

Adding a `FORMAT_PAT` repo secret with `contents: write` makes this work end to end. The repo already uses this pattern for `DOCS_STALENESS_PAT`.

## Also in this PR: gofmt sweep

`golangci-lint` v2 splits linters from formatters, and the CI job runs `golangci-lint run`, not `fmt` — so gofmt was never enforced and 26 files had drifted. Formatting them here means the new workflow lands near-empty format commits on subsequent PRs instead of one large one.

Whitespace and alignment only.

## Verification

- `go build`, `go vet ./...`, `go test ./...` all pass.
- `gofmt -l .` is empty; `rumdl check .` clean across all 130 files.
- Workflow YAML parses; `golangci-lint run` reports 0 issues.
