### PR TITLE
test: cover the deployPickAgents branches and omitempty config case

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,25 @@ func TestConfigDefaultDeployAgentsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestConfigDefaultDeployAgentsOmittedWhenEmpty(t *testing.T) {
+	c := config.Config{
+		Version:         1,
+		DefaultScope:    nd.ScopeGlobal,
+		DefaultAgent:    "claude-code",
+		SymlinkStrategy: nd.SymlinkAbsolute,
+		Sources:         []config.SourceEntry{},
+	}
+
+	data, err := yaml.Marshal(&c)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if contains(string(data), "default_deploy_agents") {
+		t.Errorf("empty default_deploy_agents should be omitted from YAML, got:\n%s", data)
+	}
+}
+
 func TestConfigValidateDefaultDeployAgentsValid(t *testing.T) {
 	c := config.Config{
 		Version:             1,

--- a/internal/tui/deploy_test.go
+++ b/internal/tui/deploy_test.go
@@ -102,6 +102,14 @@ func TestDeploy_InputActive_PickType(t *testing.T) {
 	}
 }
 
+func TestDeploy_InputActive_PickAgents(t *testing.T) {
+	ds := newTestDeployScreen(deployPickAgents)
+	// pickAgents step has a MultiSelect which is considered input-active
+	if !ds.InputActive() {
+		t.Fatal("InputActive() at pickAgents step should be true")
+	}
+}
+
 func TestDeploy_InputActive_SelectAssets(t *testing.T) {
 	ds := newTestDeployScreen(deploySelectAssets)
 	// selectAssets step has a MultiSelect which is considered input-active
@@ -770,6 +778,28 @@ func TestDeploy_FullHelpItems_PickType(t *testing.T) {
 	}
 	if !hasEnterSelect {
 		t.Errorf("FullHelpItems at pickType should include 'enter select'; got: %v", items)
+	}
+}
+
+func TestDeploy_FullHelpItems_PickAgents(t *testing.T) {
+	ds := newTestDeployScreen(deployPickAgents)
+	items := ds.FullHelpItems()
+
+	hasToggle := false
+	hasEnterConfirm := false
+	for _, item := range items {
+		if item.Key == "x/space" && item.Desc == "toggle" {
+			hasToggle = true
+		}
+		if item.Key == "enter" && item.Desc == "confirm" {
+			hasEnterConfirm = true
+		}
+	}
+	if !hasToggle {
+		t.Errorf("FullHelpItems at pickAgents should include 'x/space toggle'; got: %v", items)
+	}
+	if !hasEnterConfirm {
+		t.Errorf("FullHelpItems at pickAgents should include 'enter confirm'; got: %v", items)
 	}
 }
 


### PR DESCRIPTION
## Summary

Salvages the genuinely additive tests from #138 before closing it.

#138 implemented multi-agent deploy independently of the version that landed via #139 (backlog task `ba5xah`), which is why it conflicted in 9 files. Its implementation was redundant — everything in its scope is on `main`, and `main` goes further in places — so it is closed as superseded. Three of its tests, though, covered gaps `main`'s own tests left open.

## The three tests

**`TestConfigDefaultDeployAgentsOmittedWhenEmpty`** — `TestConfigDefaultDeployAgentsRoundTrip` asserts `default_deploy_agents` is present when set, but nothing asserted the `omitempty` tag actually drops it when empty. That tag is load-bearing for config files staying clean.

**`TestDeploy_InputActive_PickAgents`** and **`TestDeploy_FullHelpItems_PickAgents`** — `main` exercised `deployPickAgents` only through step transitions (`deploy_test.go:1047-1088`). The `pickAgents` branch of `InputActive()` (`deploy.go:175`) and of `FullHelpItems()` (`deploy.go:197`) was never reached, despite every neighbouring step having both tests.

## Deliberately not ported

- Its split merge tests — both halves are already covered by `TestMergeConfigsDefaultDeployAgents`.
- `TestDeployWithAgentsFlagBogus` — already covered by `TestDeployWithUnknownAgent`, same assertions under a different name.
- Its TUI result-view tests — not portable. They model targets as `targetAgents []*agent.Agent` with a `targetAgentNames()` helper; `main` uses `selectedAgents []string`. Porting them would mean rewriting, not moving.

## Verification

- `go build`, `go test ./...`, `golangci-lint run` (0 issues), `gofmt -l .` empty.
- All three new tests pass.

Tests only; no production code changes.
